### PR TITLE
Modernize GitHub Actions workflow and add dependency caching

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -27,10 +27,9 @@ jobs:
       - name: VCS Checkout
         uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-          override: true
+          toolchain: nightly-2024-08-19
           components: rustfmt
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: VCS Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -32,7 +32,4 @@ jobs:
           toolchain: nightly-2024-08-19
           components: rustfmt
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: "fmt"
-          args: "--all -- --check"
+        run: cargo fmt --all -- --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,4 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.5
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: nightly-2024-08-19
           components: clippy
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           toolchain: nightly-2024-08-19
           components: clippy
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.5
       - name: Run cargo clippy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,9 @@ jobs:
       - name: VCS Checkout
         uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-          override: true
+          toolchain: nightly-2024-08-19
           components: clippy
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: VCS Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,25 +25,25 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: VCS Checkout
-      uses: actions/checkout@v3
-    - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
-    - name: Build (Release Mode)
-      uses: actions-rs/cargo@v1
-      with:
-        command: "build"
-        args: "--release --verbose"
-    - name: Test (Release Mode)
-      uses: actions-rs/cargo@v1
-      with:
-        command: "test"
-        args: "--release --verbose"
+      - name: VCS Checkout
+        uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: Build (Release Mode)
+        uses: actions-rs/cargo@v1
+        with:
+          command: "build"
+          args: "--release --verbose"
+      - name: Test (Release Mode)
+        uses: actions-rs/cargo@v1
+        with:
+          command: "test"
+          args: "--release --verbose"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.5
       - name: Build (Release Mode)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: VCS Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           toolchain: nightly
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Build (Release Mode)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-08-19
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,12 +39,6 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.5
       - name: Build (Release Mode)
-        uses: actions-rs/cargo@v1
-        with:
-          command: "build"
-          args: "--release --verbose"
+        run: cargo build --release --verbose
       - name: Test (Release Mode)
-        uses: actions-rs/cargo@v1
-        with:
-          command: "test"
-          args: "--release --verbose"
+        run: cargo test --release --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,9 @@ jobs:
       - name: VCS Checkout
         uses: actions/checkout@v4
       - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: Build (Release Mode)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = [ "rustfmt", "clippy" ]
+channel = "nightly-2024-08-19"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
* Upgrade to latest version of actions/checkout
* Upgrade gh-action mozilla-actions/sccache-action 0.0.3 -> 0.0.5
* Migrate from gh-action actions-rs/toolchain to dtolnay/rust-toolchain
* Pin version of nightly in order to make caching more effective