### PR TITLE
Stable Rust

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.5
       - name: Run cargo-tarpaulin
-        run: cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+        run: cargo +nightly tarpaulin --engine llvm --verbose --all-features --workspace --timeout 120 --out xml
       # Note: closed-source code needs to provide a token,
       # but open source code does not.
       - name: Upload to codecov.io

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
       # Note: closed-source code needs to provide a token,
       # but open source code does not.
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v4.5.0
         with:
           verbose: true
           fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        toolchain: [ stable, nightly-2024-08-19 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: VCS Checkout
@@ -34,7 +35,7 @@ jobs:
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-08-19
+          toolchain: ${{ matrix.toolchain }}
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache

--- a/.run/Bench.run.xml
+++ b/.run/Bench.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Build" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="buildProfileId" value="dev" />
-    <option name="command" value="build" />
+  <configuration default="false" name="Bench" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="bench" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs>
       <env name="RUSTC_WRAPPER" value="sccache" />

--- a/.run/Build Stable.run.xml
+++ b/.run/Build Stable.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build Stable" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="dev" />
+    <option name="command" value="build" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs>
+      <env name="RUSTC_WRAPPER" value="sccache" />
+    </envs>
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="STABLE" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="FULL" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Run.run.xml
+++ b/.run/Run.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="dev" />
     <option name="command" value="run --bin reactive-graph" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs>

--- a/.run/Tarpaulin.run.xml
+++ b/.run/Tarpaulin.run.xml
@@ -1,15 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Tarpaulin" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="tarpaulin --verbose --out Xml" />
+    <option name="command" value="tarpaulin --engine llvm --verbose --out Xml" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="false" />
     <option name="channel" value="NIGHTLY" />
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
-    <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="FULL" />
-    <envs />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/.run/Test Stable.run.xml
+++ b/.run/Test Stable.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Test Stable" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs>
+      <env name="RUSTC_WRAPPER" value="sccache" />
+    </envs>
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="STABLE" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="FULL" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Test.run.xml
+++ b/.run/Test.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="buildProfile" value="Test" />
+    <option name="buildProfileId" value="test" />
     <option name="command" value="test" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ chrono = { version = "0.4", features = ["serde"] }
 colored = "2.0"
 config = "0.14.0"
 convert_case = "0.6"
+criterion = { version = "0.5", features = ["html_reports"] }
 crossbeam = "0.8"
 cynic = { version = "3.7", features = ["http-reqwest"], default-features = false }
 darling = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ rayon = "1.6"
 regex = "1.9"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 rust-embed = { version = "8.0", features = ["debug-embed", "compression"] }
+rustc_version = "0.4"
 rustls = { version = "0.23.13", features = ["aws_lc_rs"] }
 rustls-pki-types = "1.4.0"
 rustls-pemfile = "2.1.1"

--- a/crates/behaviour/model/impl/Cargo.toml
+++ b/crates/behaviour/model/impl/Cargo.toml
@@ -27,3 +27,6 @@ random-string = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/behaviour/model/impl/src/lib.rs
+++ b/crates/behaviour/model/impl/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(register_tool)]
-#![register_tool(tarpaulin)]
-
 pub use behaviour::BehaviourConnect;
 pub use behaviour::BehaviourConnectFailed;
 pub use behaviour::BehaviourCreationError;
@@ -45,5 +42,5 @@ pub mod entity;
 pub mod relation;
 
 #[cfg(test)]
-#[tarpaulin::ignore]
+#[cfg(not(tarpaulin_include))]
 pub mod tests;

--- a/crates/behaviour/model/impl/src/tests/mod.rs
+++ b/crates/behaviour/model/impl/src/tests/mod.rs
@@ -1,6 +1,6 @@
 mod expression_test;
 
-#[tarpaulin::skip]
+#[cfg(not(tarpaulin_include))]
 pub mod utils;
 
 #[test]

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -36,3 +36,6 @@ test = ["default-test", "rand", "rand_derive2", "reactive-graph-test-utils"]
 
 [lib]
 crate-type = ["lib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/graph/src/instances/flows/mod.rs
+++ b/crates/graph/src/instances/flows/mod.rs
@@ -3,5 +3,5 @@ pub use flow_instance::*;
 pub mod flow_instance;
 
 #[cfg(test)]
-#[tarpaulin::ignore]
+#[cfg(not(tarpaulin_include))]
 mod flow_instance_test;

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(register_tool)]
-#![register_tool(tarpaulin)]
-
 pub use types::components::*;
 pub use types::entities::*;
 pub use types::extensions::*;

--- a/crates/plugin/api/Cargo.toml
+++ b/crates/plugin/api/Cargo.toml
@@ -49,3 +49,6 @@ full = ["derive", "springtime"] #, "json5", "toml" ]
 
 [lib]
 crate-type = ["lib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/plugin/api/src/lib.rs
+++ b/crates/plugin/api/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(concat_idents)]
-
 #[cfg(feature = "json5")]
 pub use json5;
 pub use serde_json;

--- a/crates/plugin/api/src/lib.rs
+++ b/crates/plugin/api/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(register_tool)]
 #![feature(concat_idents)]
-#![register_tool(tarpaulin)]
 
 #[cfg(feature = "json5")]
 pub use json5;
@@ -413,5 +411,5 @@ macro_rules! get_context {
 pub mod prelude;
 
 #[cfg(test)]
-#[tarpaulin::ignore]
+#[cfg(not(tarpaulin_include))]
 pub mod tests;

--- a/crates/plugin/service/impl/src/lib.rs
+++ b/crates/plugin/service/impl/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(path_file_prefix)]
-
 pub use container::*;
 pub use context::*;
 pub use plugin_container_manager_impl::*;

--- a/crates/plugin/service/impl/src/plugin_paths.rs
+++ b/crates/plugin/service/impl/src/plugin_paths.rs
@@ -1,4 +1,5 @@
 use std::env::consts::DLL_EXTENSION;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -10,7 +11,7 @@ fn get_timestamp() -> u64 {
 
 // TODO: replace relative with absolute path replacement
 pub fn get_deploy_path(path: &Path) -> Option<PathBuf> {
-    path.file_prefix().and_then(|file_prefix| {
+    file_prefix(path).and_then(|file_prefix| {
         path.parent()
             .and_then(|path| path.parent())
             .map(|path| path.join("deploy").join(file_prefix).with_extension(DLL_EXTENSION))
@@ -19,7 +20,7 @@ pub fn get_deploy_path(path: &Path) -> Option<PathBuf> {
 
 // TODO: replace relative with absolute path replacement
 pub fn get_install_path(path: &Path) -> Option<PathBuf> {
-    path.file_prefix().and_then(|file_prefix| {
+    file_prefix(path).and_then(|file_prefix| {
         path.parent().and_then(|path| path.parent()).map(|path| {
             path.join("installed")
                 .join(file_prefix)
@@ -29,5 +30,41 @@ pub fn get_install_path(path: &Path) -> Option<PathBuf> {
 }
 
 pub fn get_stem(path: &Path) -> Option<String> {
-    path.file_prefix().and_then(|stem| Some(stem.to_str()?.to_string()))
+    file_prefix(path).and_then(|stem| Some(stem.to_str()?.to_string()))
+}
+
+// Use this workaround until #![feature(path_file_prefix)] is stabilized
+pub fn file_prefix(path: &Path) -> Option<&OsStr> {
+    path.file_name().map(split_file_at_dot).and_then(|(before, _after)| Some(before))
+}
+
+// Use this workaround until #![feature(path_file_prefix)] is stabilized
+fn split_file_at_dot(file: &OsStr) -> (&OsStr, Option<&OsStr>) {
+    let slice = os_str_as_u8_slice(file);
+    if slice == b".." {
+        return (file, None);
+    }
+
+    // The unsafety here stems from converting between &OsStr and &[u8]
+    // and back. This is safe to do because (1) we only look at ASCII
+    // contents of the encoding and (2) new &OsStr values are produced
+    // only from ASCII-bounded slices of existing &OsStr values.
+    let i = match slice[1..].iter().position(|b| *b == b'.') {
+        Some(i) => i + 1,
+        None => return (file, None),
+    };
+    let before = &slice[..i];
+    let after = &slice[i + 1..];
+    unsafe { (u8_slice_as_os_str(before), Some(u8_slice_as_os_str(after))) }
+}
+
+// Use this workaround until #![feature(path_file_prefix)] is stabilized
+fn os_str_as_u8_slice(s: &OsStr) -> &[u8] {
+    unsafe { &*(s as *const OsStr as *const [u8]) }
+}
+
+// Use this workaround until #![feature(path_file_prefix)] is stabilized
+unsafe fn u8_slice_as_os_str(s: &[u8]) -> &OsStr {
+    // SAFETY: see the comment of `os_str_as_u8_slice`
+    unsafe { &*(s as *const [u8] as *const OsStr) }
 }

--- a/crates/reactive/model/impl/Cargo.toml
+++ b/crates/reactive/model/impl/Cargo.toml
@@ -23,6 +23,7 @@ reactive-graph-reactive-model-api = { version = "0.10.0", path = "../api" }
 reactive-graph-test-utils = { version = "0.10.0", path = "../../../test-utils", optional = true }
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
 default-test = { workspace = true }
 random-string = { workspace = true }
 rand = { workspace = true }
@@ -36,3 +37,7 @@ crate-type = ["lib"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+
+[[bench]]
+name = "reactive_property_instance_stream"
+harness = false

--- a/crates/reactive/model/impl/Cargo.toml
+++ b/crates/reactive/model/impl/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme = "../../../../README.md"
 
 [dependencies]
-dashmap = { workspace = true }
+dashmap = { workspace = true, features = ["rayon"] }
 rayon = { workspace = true }
 schemars = { workspace = true, features = ["uuid1"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/reactive/model/impl/Cargo.toml
+++ b/crates/reactive/model/impl/Cargo.toml
@@ -33,3 +33,6 @@ reactive-graph-test-utils = { version = "0.10.0", path = "../../../test-utils" }
 
 [lib]
 crate-type = ["lib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/reactive/model/impl/benches/reactive_property_instance_stream.rs
+++ b/crates/reactive/model/impl/benches/reactive_property_instance_stream.rs
@@ -1,0 +1,54 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use rand::Rng;
+use reactive_graph_graph::Mutability::Mutable;
+use reactive_graph_reactive_model_impl::ReactiveProperty;
+use reactive_graph_test_utils::r_string;
+use serde_json::json;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use uuid::Uuid;
+
+fn reactive_property_instance_stream(criterion: &mut Criterion) {
+    criterion.bench_function("reactive_property_instance_stream", move |bencher| {
+        let instance1 = ReactiveProperty::new(Uuid::new_v4(), r_string(), Mutable, json!(0));
+        let instance2 = ReactiveProperty::new(Uuid::new_v4(), r_string(), Mutable, json!(0));
+
+        let v = Arc::new(AtomicU64::new(0));
+
+        {
+            let v = v.clone();
+            let writer = instance2.stream.write().unwrap();
+            let handle_id = Uuid::new_v4().as_u128();
+            writer.observe_with_handle(
+                move |value| {
+                    v.store(value.as_u64().unwrap(), Ordering::Relaxed);
+                },
+                handle_id,
+            );
+        }
+
+        {
+            let writer = instance1.stream.write().unwrap();
+            let handle_id = Uuid::new_v4().as_u128();
+            writer.observe_with_handle(
+                move |value| {
+                    instance2.set(value.clone());
+                },
+                handle_id,
+            );
+        }
+
+        let mut rng = rand::thread_rng();
+        bencher.iter(move || {
+            let number: u64 = rng.gen();
+            instance1.set(json!(number));
+            assert_eq!(number, v.load(Ordering::Relaxed));
+        })
+    });
+}
+
+criterion_group!(benches, reactive_property_instance_stream,);
+criterion_main!(benches);

--- a/crates/reactive/model/impl/src/frp/mod.rs
+++ b/crates/reactive/model/impl/src/frp/mod.rs
@@ -650,5 +650,5 @@ where
 }
 
 #[cfg(test)]
-#[tarpaulin::ignore]
+#[cfg(not(tarpaulin_include))]
 mod tests;

--- a/crates/reactive/model/impl/src/lib.rs
+++ b/crates/reactive/model/impl/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(test)]
-
 pub use entities::*;
 pub use flows::*;
 pub use frp::*;

--- a/crates/reactive/model/impl/src/lib.rs
+++ b/crates/reactive/model/impl/src/lib.rs
@@ -1,7 +1,4 @@
-#![feature(unsized_tuple_coercion)]
-#![feature(register_tool)]
 #![feature(test)]
-#![register_tool(tarpaulin)]
 
 pub use entities::*;
 pub use flows::*;

--- a/crates/reactive/service/api/Cargo.toml
+++ b/crates/reactive/service/api/Cargo.toml
@@ -28,6 +28,9 @@ reactive-graph-behaviour-model-api = { version = "0.10.0", path = "../../../beha
 reactive-graph-behaviour-service-api = { version = "0.10.0", path = "../../../behaviour/service/api" }
 reactive-graph-type-system-api = { version = "0.10.0", path = "../../../type-system/api" }
 
+[build-dependencies]
+rustc_version = { workspace = true }
+
 [dev-dependencies]
 default-test = { workspace = true }
 
@@ -36,6 +39,10 @@ reactive-graph-test-utils = { version = "0.10.0", path = "../../../test-utils" }
 [features]
 default = ["derive"]
 derive = ["reactive-graph-reactive-derive"]
+rustc_nightly = []
 
 [lib]
 crate-type = ["lib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rustc_nightly)'] }

--- a/crates/reactive/service/api/build.rs
+++ b/crates/reactive/service/api/build.rs
@@ -1,0 +1,21 @@
+extern crate rustc_version;
+use rustc_version::version_meta;
+use rustc_version::Channel;
+
+fn main() {
+    // Set cfg flags depending on release channel
+    match version_meta().unwrap().channel {
+        Channel::Stable => {
+            println!("cargo:rustc-cfg=rustc_stable");
+        }
+        Channel::Beta => {
+            println!("cargo:rustc-cfg=rustc_beta");
+        }
+        Channel::Nightly => {
+            println!("cargo:rustc-cfg=rustc_nightly");
+        }
+        Channel::Dev => {
+            println!("cargo:rustc-cfg=rustc_dev");
+        }
+    }
+}

--- a/crates/reactive/service/api/src/lib.rs
+++ b/crates/reactive/service/api/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(unboxed_closures)]
-#![feature(fn_traits)]
+#![cfg_attr(feature = "rustc_nightly", feature(unboxed_closures, fn_traits))]
 
 pub use error::entity::*;
 pub use error::flow::*;

--- a/crates/reactive/service/api/src/property/property_bool/callable.rs
+++ b/crates/reactive/service/api/src/property/property_bool/callable.rs
@@ -2,6 +2,7 @@ use crate::TypedReactivePropertyImpl;
 use reactive_graph_reactive_model_api::ReactiveInstance;
 use serde_json::json;
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnOnce<(bool,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, bool>
 where
     IdType: Clone,
@@ -14,6 +15,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnMut<(bool,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, bool>
 where
     IdType: Clone,
@@ -24,6 +26,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> Fn<(bool,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, bool>
 where
     IdType: Clone,

--- a/crates/reactive/service/api/src/property/property_f64/callable.rs
+++ b/crates/reactive/service/api/src/property/property_f64/callable.rs
@@ -2,6 +2,7 @@ use crate::TypedReactivePropertyImpl;
 use reactive_graph_reactive_model_api::ReactiveInstance;
 use serde_json::json;
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnOnce<(f64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, f64>
 where
     IdType: Clone,
@@ -14,6 +15,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnMut<(f64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, f64>
 where
     IdType: Clone,
@@ -24,6 +26,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> Fn<(f64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, f64>
 where
     IdType: Clone,

--- a/crates/reactive/service/api/src/property/property_i64/callable.rs
+++ b/crates/reactive/service/api/src/property/property_i64/callable.rs
@@ -2,6 +2,7 @@ use crate::TypedReactivePropertyImpl;
 use reactive_graph_reactive_model_api::ReactiveInstance;
 use serde_json::json;
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnOnce<(i64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, i64>
 where
     IdType: Clone,
@@ -14,6 +15,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnMut<(i64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, i64>
 where
     IdType: Clone,
@@ -24,6 +26,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> Fn<(i64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, i64>
 where
     IdType: Clone,

--- a/crates/reactive/service/api/src/property/property_string/callable.rs
+++ b/crates/reactive/service/api/src/property/property_string/callable.rs
@@ -2,6 +2,7 @@ use crate::TypedReactivePropertyImpl;
 use reactive_graph_reactive_model_api::ReactiveInstance;
 use serde_json::json;
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnOnce<(String,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, String>
 where
     IdType: Clone,
@@ -14,6 +15,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnMut<(String,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, String>
 where
     IdType: Clone,
@@ -24,6 +26,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> Fn<(String,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, String>
 where
     IdType: Clone,

--- a/crates/reactive/service/api/src/property/property_u64/callable.rs
+++ b/crates/reactive/service/api/src/property/property_u64/callable.rs
@@ -2,6 +2,7 @@ use crate::TypedReactivePropertyImpl;
 use reactive_graph_reactive_model_api::ReactiveInstance;
 use serde_json::json;
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnOnce<(u64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, u64>
 where
     IdType: Clone,
@@ -14,6 +15,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> FnMut<(u64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, u64>
 where
     IdType: Clone,
@@ -24,6 +26,7 @@ where
     }
 }
 
+#[cfg(feature = "rustc_nightly")]
 impl<IdType, ReactiveInstanceType> Fn<(u64,)> for TypedReactivePropertyImpl<IdType, ReactiveInstanceType, u64>
 where
     IdType: Clone,

--- a/crates/reactive/service/impl/Cargo.toml
+++ b/crates/reactive/service/impl/Cargo.toml
@@ -31,6 +31,7 @@ reactive-graph-lifecycle = { version = "0.10.0", path = "../../../lifecycle" }
 reactive-graph-type-system-api = { version = "0.10.0", path = "../../../type-system/api" }
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
 default-test = { workspace = true }
 log4rs = { workspace = true, features = ["console_appender"] }
 
@@ -43,3 +44,7 @@ reactive-graph-behaviour-service-impl = { version = "0.10.0", path = "../../../b
 
 [lib]
 crate-type = ["lib"]
+
+[[bench]]
+name = "reactive_entity_manager"
+harness = false

--- a/crates/reactive/service/impl/benches/reactive_entity_manager.rs
+++ b/crates/reactive/service/impl/benches/reactive_entity_manager.rs
@@ -1,0 +1,87 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use default_test::DefaultTest;
+use reactive_graph_graph::EntityType;
+use reactive_graph_graph::PropertyInstanceSetter;
+use reactive_graph_graph::PropertyType;
+use reactive_graph_reactive_model_impl::ReactiveEntity;
+use reactive_graph_reactive_service_api::ReactiveSystem;
+use reactive_graph_reactive_service_impl::ReactiveSystemImpl;
+use serde_json::json;
+
+// Do not remove! This import is necessary to make the dependency injection work
+#[allow(unused_imports)]
+use reactive_graph_behaviour_service_impl::BehaviourSystemImpl;
+// Do not remove! This import is necessary to make the dependency injection work
+#[allow(unused_imports)]
+use reactive_graph_type_system_impl::TypeSystemImpl;
+
+fn create_reactive_entity(criterion: &mut Criterion) {
+    criterion.bench_function("create_reactive_entity", move |bencher| {
+        let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
+        let type_system = reactive_system.type_system();
+        let entity_type_manager = type_system.get_entity_type_manager();
+        let reactive_entity_manager = reactive_system.get_reactive_entity_manager();
+
+        let entity_type = entity_type_manager
+            .register(EntityType::default_test())
+            .expect("Failed to register entity type");
+
+        bencher.iter(move || {
+            let reactive_entity = ReactiveEntity::builder_from_entity_type(&entity_type).build();
+            reactive_entity_manager
+                .register_reactive_instance(reactive_entity)
+                .expect("Failed to register reactive instance");
+        })
+    });
+}
+
+fn get_reactive_entity_by_id(criterion: &mut Criterion) {
+    criterion.bench_function("get_reactive_entity_by_id", move |bencher| {
+        let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
+        let type_system = reactive_system.type_system();
+        let entity_type_manager = type_system.get_entity_type_manager();
+        let reactive_entity_manager = reactive_system.get_reactive_entity_manager();
+
+        let entity_type = entity_type_manager
+            .register(EntityType::default_test())
+            .expect("Failed to register entity type");
+
+        let reactive_entity = ReactiveEntity::builder_from_entity_type(&entity_type).build();
+        let id = reactive_entity.id;
+
+        reactive_entity_manager
+            .register_reactive_instance(reactive_entity)
+            .expect("Failed to register reactive instance");
+
+        bencher.iter(|| reactive_entity_manager.get(id))
+    });
+}
+
+fn get_reactive_entity_by_label(criterion: &mut Criterion) {
+    criterion.bench_function("get_reactive_entity_by_label", move |bencher| {
+        let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
+        let type_system = reactive_system.type_system();
+        let entity_type_manager = type_system.get_entity_type_manager();
+        let reactive_entity_manager = reactive_system.get_reactive_entity_manager();
+
+        let entity_type = EntityType::default_test();
+        entity_type.properties.push(PropertyType::string("label"));
+
+        let entity_type = entity_type_manager.register(entity_type).expect("Failed to register entity type");
+
+        let label = String::from("/org/inexor/test");
+
+        let reactive_entity = ReactiveEntity::builder_from_entity_type(&entity_type).build();
+        reactive_entity.set("label", json!(label.clone()));
+        reactive_entity_manager
+            .register_reactive_instance(reactive_entity)
+            .expect("Failed to register reactive entity");
+
+        bencher.iter(|| reactive_entity_manager.get_by_label(&label))
+    });
+}
+
+criterion_group!(benches, create_reactive_entity, get_reactive_entity_by_id, get_reactive_entity_by_label);
+criterion_main!(benches);

--- a/crates/reactive/service/impl/src/lib.rs
+++ b/crates/reactive/service/impl/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(test)]
-
 pub use reactive_entity_manager_impl::*;
 pub use reactive_flow_manager_impl::*;
 pub use reactive_instance_event_manager_impl::*;
@@ -11,6 +9,3 @@ pub mod reactive_flow_manager_impl;
 pub mod reactive_instance_event_manager_impl;
 pub mod reactive_relation_manager_impl;
 pub mod reactive_system_impl;
-
-// #[cfg(test)]
-// mod test;

--- a/crates/reactive/service/impl/src/reactive_entity_manager_impl.rs
+++ b/crates/reactive/service/impl/src/reactive_entity_manager_impl.rs
@@ -618,21 +618,13 @@ impl Lifecycle for ReactiveEntityManagerImpl {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
-
-    use std::process::Termination;
-    use test::Bencher;
-
     use default_test::DefaultTest;
-    use serde_json::json;
 
     // Do not remove! This import is necessary to make the dependency injection work
     #[allow(unused_imports)]
     use reactive_graph_behaviour_service_impl::BehaviourSystemImpl;
     use reactive_graph_graph::EntityType;
     use reactive_graph_graph::EntityTypeId;
-    use reactive_graph_graph::PropertyInstanceSetter;
-    use reactive_graph_graph::PropertyType;
     use reactive_graph_graph::PropertyTypes;
     use reactive_graph_reactive_model_impl::ReactiveEntity;
     use reactive_graph_reactive_service_api::ReactiveSystem;
@@ -684,9 +676,6 @@ mod tests {
     #[test]
     fn test_unregister_reactive_entity_instance() {
         reactive_graph_test_utils::init_logger();
-        // let runtime = get_runtime();
-        // let entity_type_manager = runtime.get_entity_type_manager();
-        // let reactive_entity_manager = runtime.get_reactive_entity_manager();
 
         let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
         let type_system = reactive_system.type_system();
@@ -716,9 +705,6 @@ mod tests {
     #[test]
     fn test_not_register_twice_reactive_entity_instance() {
         reactive_graph_test_utils::init_logger();
-        // let runtime: Arc<dyn Runtime + Send + Sync> = get_runtime();
-        // let entity_type_manager = runtime.get_entity_type_manager();
-        // let reactive_entity_manager = runtime.get_reactive_entity_manager();
 
         let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
         let type_system = reactive_system.type_system();
@@ -759,80 +745,5 @@ mod tests {
 
         assert!(reactive_entity_manager.has(id), "The reactive entity with id should be registered!");
         assert_eq!(reactive_entity_manager.count(), 1);
-    }
-
-    #[bench]
-    fn creation_benchmark(bencher: &mut Bencher) -> impl Termination {
-        // let runtime = get_runtime();
-        // let entity_type_manager = runtime.get_entity_type_manager();
-        // let reactive_entity_manager = runtime.get_reactive_entity_manager();
-
-        let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
-        let type_system = reactive_system.type_system();
-        let entity_type_manager = type_system.get_entity_type_manager();
-        let reactive_entity_manager = reactive_system.get_reactive_entity_manager();
-
-        let entity_type = entity_type_manager
-            .register(EntityType::default_test())
-            .expect("Failed to register entity type");
-
-        bencher.iter(move || {
-            let reactive_entity = ReactiveEntity::builder_from_entity_type(&entity_type).build();
-            reactive_entity_manager
-                .register_reactive_instance(reactive_entity)
-                .expect("Failed to register reactive instance");
-        })
-    }
-
-    #[bench]
-    fn get_by_id_benchmark(bencher: &mut Bencher) -> impl Termination {
-        // let runtime = get_runtime();
-        // let entity_type_manager = runtime.get_entity_type_manager();
-        // let reactive_entity_manager = runtime.get_reactive_entity_manager();
-
-        let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
-        let type_system = reactive_system.type_system();
-        let entity_type_manager = type_system.get_entity_type_manager();
-        let reactive_entity_manager = reactive_system.get_reactive_entity_manager();
-
-        let entity_type = entity_type_manager
-            .register(EntityType::default_test())
-            .expect("Failed to register entity type");
-
-        let reactive_entity = ReactiveEntity::builder_from_entity_type(&entity_type).build();
-        let id = reactive_entity.id;
-
-        reactive_entity_manager
-            .register_reactive_instance(reactive_entity)
-            .expect("Failed to register reactive instance");
-
-        bencher.iter(|| reactive_entity_manager.get(id))
-    }
-
-    #[bench]
-    fn get_by_label_benchmark(bencher: &mut Bencher) -> impl Termination {
-        // let runtime = get_runtime();
-        // let entity_type_manager = runtime.get_entity_type_manager();
-        // let reactive_entity_manager = runtime.get_reactive_entity_manager();
-
-        let reactive_system = reactive_graph_di::get_container::<ReactiveSystemImpl>();
-        let type_system = reactive_system.type_system();
-        let entity_type_manager = type_system.get_entity_type_manager();
-        let reactive_entity_manager = reactive_system.get_reactive_entity_manager();
-
-        let entity_type = EntityType::default_test();
-        entity_type.properties.push(PropertyType::string("label"));
-
-        let entity_type = entity_type_manager.register(entity_type).expect("Failed to register entity type");
-
-        let label = String::from("/org/inexor/test");
-
-        let reactive_entity = ReactiveEntity::builder_from_entity_type(&entity_type).build();
-        reactive_entity.set("label", json!(label.clone()));
-        reactive_entity_manager
-            .register_reactive_instance(reactive_entity)
-            .expect("Failed to register reactive entity");
-
-        bencher.iter(|| reactive_entity_manager.get_by_label(&label))
     }
 }

--- a/crates/runtime/impl/Cargo.toml
+++ b/crates/runtime/impl/Cargo.toml
@@ -138,3 +138,6 @@ crate-type = ["lib"]
 
 [[example]]
 name = "simple_runtime"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/runtime/impl/src/lib.rs
+++ b/crates/runtime/impl/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(concat_idents)]
 #![allow(clippy::map_entry, clippy::module_inception, clippy::too_many_arguments)]
 
 // async fn in traits + async closures

--- a/crates/runtime/impl/src/lib.rs
+++ b/crates/runtime/impl/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(concat_idents)]
-#![feature(test)]
 #![allow(clippy::map_entry, clippy::module_inception, clippy::too_many_arguments)]
 
 // async fn in traits + async closures

--- a/crates/runtime/impl/src/lib.rs
+++ b/crates/runtime/impl/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(concat_idents)]
 #![feature(test)]
-#![feature(path_file_prefix)]
 #![allow(clippy::map_entry, clippy::module_inception, clippy::too_many_arguments)]
 
 // async fn in traits + async closures

--- a/crates/runtime/impl/src/lib.rs
+++ b/crates/runtime/impl/src/lib.rs
@@ -1,8 +1,6 @@
 #![feature(concat_idents)]
-#![feature(register_tool)]
 #![feature(test)]
 #![feature(path_file_prefix)]
-#![register_tool(tarpaulin)]
 #![allow(clippy::map_entry, clippy::module_inception, clippy::too_many_arguments)]
 
 // async fn in traits + async closures

--- a/crates/runtime/service/test/Cargo.toml
+++ b/crates/runtime/service/test/Cargo.toml
@@ -18,3 +18,6 @@ reactive-graph-runtime-impl = { version = "0.10.0", path = "../../impl" }
 
 [lib]
 crate-type = ["lib"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/crates/type-system/impl/Cargo.toml
+++ b/crates/type-system/impl/Cargo.toml
@@ -26,6 +26,7 @@ reactive-graph-type-system-api = { version = "0.10.0", path = "../api", features
 reactive-graph-reactive-model-impl = { version = "0.10.0", path = "../../reactive/model/impl" }
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
 default-test = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time", "rt", "rt-multi-thread", "test-util"] }
 
@@ -43,3 +44,11 @@ full = ["springtime", "json5", "toml"]
 
 [lib]
 crate-type = ["lib"]
+
+[[bench]]
+name = "component_manager"
+harness = false
+
+[[bench]]
+name = "entity_type_manager"
+harness = false

--- a/crates/type-system/impl/benches/component_manager.rs
+++ b/crates/type-system/impl/benches/component_manager.rs
@@ -1,0 +1,24 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use default_test::DefaultTest;
+use reactive_graph_graph::Component;
+use reactive_graph_type_system_api::TypeSystem;
+use reactive_graph_type_system_impl::TypeSystemImpl;
+
+fn create_components(criterion: &mut Criterion) {
+    reactive_graph_test_utils::init_logger();
+    criterion.bench_function("create_components", move |bencher| {
+        let type_system = reactive_graph_di::get_container::<TypeSystemImpl>();
+        let component_manager = type_system.get_component_manager();
+        let component = Component::default_test();
+        let ty = component.ty.clone();
+        bencher.iter(move || {
+            let _ = component_manager.register(component.clone());
+            component_manager.delete(&ty);
+        })
+    });
+}
+
+criterion_group!(benches, create_components,);
+criterion_main!(benches);

--- a/crates/type-system/impl/benches/entity_type_manager.rs
+++ b/crates/type-system/impl/benches/entity_type_manager.rs
@@ -1,0 +1,24 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use default_test::DefaultTest;
+use reactive_graph_graph::EntityType;
+use reactive_graph_type_system_api::TypeSystem;
+use reactive_graph_type_system_impl::TypeSystemImpl;
+
+fn create_entity_type(criterion: &mut Criterion) {
+    reactive_graph_test_utils::init_logger();
+    criterion.bench_function("create_reactive_entity", move |bencher| {
+        let type_system = reactive_graph_di::get_container::<TypeSystemImpl>();
+        let entity_type_manager = type_system.get_entity_type_manager();
+        let entity_type = EntityType::default_test();
+        let ty = entity_type.ty.clone();
+        bencher.iter(move || {
+            let _ = entity_type_manager.register(entity_type.clone());
+            let _ = entity_type_manager.delete(&ty);
+        })
+    });
+}
+
+criterion_group!(benches, create_entity_type);
+criterion_main!(benches);

--- a/crates/type-system/impl/src/component_import_export_manager_impl.rs
+++ b/crates/type-system/impl/src/component_import_export_manager_impl.rs
@@ -82,8 +82,6 @@ impl Lifecycle for ComponentImportExportManagerImpl {}
 
 #[cfg(test)]
 mod test {
-    extern crate test;
-
     use std::env;
 
     use default_test::DefaultTest;

--- a/crates/type-system/impl/src/component_manager_impl.rs
+++ b/crates/type-system/impl/src/component_manager_impl.rs
@@ -257,12 +257,6 @@ impl Lifecycle for ComponentManagerImpl {
 
 #[cfg(test)]
 mod test {
-    extern crate test;
-
-    use std::process::Termination;
-    use test::Bencher;
-
-    use default_test::DefaultTest;
     use reactive_graph_graph::Component;
     use reactive_graph_graph::ComponentTypeId;
     use reactive_graph_graph::Extension;
@@ -316,18 +310,5 @@ mod test {
             assert!(component_manager.has(&component.ty));
         }
         assert!(!component_manager.has(&ComponentTypeId::new_from_type(r_string(), r_string())));
-    }
-
-    #[bench]
-    fn creation_benchmark(bencher: &mut Bencher) -> impl Termination {
-        reactive_graph_test_utils::init_logger();
-        let type_system = reactive_graph_di::get_container::<TypeSystemImpl>();
-        let component_manager = type_system.get_component_manager();
-        let component = Component::default_test();
-        let ty = component.ty.clone();
-        bencher.iter(move || {
-            let _ = component_manager.register(component.clone());
-            component_manager.delete(&ty);
-        })
     }
 }

--- a/crates/type-system/impl/src/entity_type_manager_impl.rs
+++ b/crates/type-system/impl/src/entity_type_manager_impl.rs
@@ -338,11 +338,6 @@ impl Lifecycle for EntityTypeManagerImpl {
 
 #[cfg(test)]
 mod test {
-    extern crate test;
-
-    use std::process::Termination;
-    use test::Bencher;
-
     use default_test::DefaultTest;
 
     use crate::TypeSystemImpl;
@@ -470,18 +465,5 @@ mod test {
         // let entity_type = EntityType::new(&entity_ty, String::new(), vec![], vec![property_type], vec![]);
         // assert!(entity_type_manager.register(entity_type).is_ok());
         // assert!(entity_type_manager.get(&entity_ty).unwrap().has_own_property(property_name.as_str()));
-    }
-
-    #[bench]
-    fn creation_benchmark(bencher: &mut Bencher) -> impl Termination {
-        reactive_graph_test_utils::init_logger();
-        let type_system = reactive_graph_di::get_container::<TypeSystemImpl>();
-        let entity_type_manager = type_system.get_entity_type_manager();
-        let entity_type = EntityType::default_test();
-        let ty = entity_type.ty.clone();
-        bencher.iter(move || {
-            let _ = entity_type_manager.register(entity_type.clone());
-            let _ = entity_type_manager.delete(&ty);
-        })
     }
 }

--- a/crates/type-system/impl/src/lib.rs
+++ b/crates/type-system/impl/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(test)]
-
 pub use component_import_export_manager_impl::*;
 pub use component_manager_impl::*;
 pub use component_provider_registry_impl::*;


### PR DESCRIPTION
# Stable Rust

## Summary

This pull request tries to get closer to the goal of compiling with stable rust.

Currently, it's not possible to compile with stable rust, though. There are more blockers (`unboxed_closures`, `fn_traits` and `concat_idents`) that hopefully will be addressed soon.

## Migration steps

### `#![feature(unsized_tuple_coercion)]`

* Implemented `DashMap` as container for subscribers of `Stream`
* Removed feature flag `unsized_tuple_coercion`
* Limitation for now: Stream propagation is no more in parallel (have to solve how to integrate with rayon)
* Compiles, Test suite passes

### `#![feature(register_tool)]`

* Removed all usages of `register_tool`
* Whitelisted unexpected cfg `tarpaulin_include`
* [Use llvm engine when running code coverage](https://github.com/xd009642/tarpaulin/issues/1056) because of stuck tests with `tokio:test`

### `#![feature(path_file_prefix)]`

* Removed all usages of `path_file_prefix`
* Inlined code from unstable rust of the `file_prefix` method (will be reverted when `path_file_prefix` has been stabilized)

### `#![feature(test)]`

* Removed all usages of `test`
* Extracted benchmarks into own `benches/` folders and refactored them to run on top of [criterion](https://crates.io/crates/criterion)
* #2 will probably profit from this

### `#![feature(concat_idents)]`

* Actually not in use - this makes the things very simple
* Removed all usages of `concat_idents`

### #![feature(unboxed_closures)] and #![feature(fn_traits)]

* Affects only one crate
* Directly access properties as functions
* Detecting nightly or stable using `build.rs` and `rustc_version`
* Dynamically create a feature by rustc channel: `rustc_stable`, `rustc_beta` and `rustc_nightly`
* Conditionally compile with #![feature(unboxed_closures)] and #![feature(fn_traits)] if compiler is nightly (`rustc_nightly`)
* Conditionally implement `FnOnce<(datatype,)>`, `FnMut<(datatype,)>` and `Fn<(datatype,)>` using `rust-call` if compiler is nightly (`rustc_nightly`)
* Compiles on nightly, Test suite passes
* Compiles on stable, Test suite passes
* Obviously the `rust-call` methods haven't been covered by unit tests since no tests failed on stable rust -> we should add unit tests

