### PR TITLE
Added option to run the server process as daemon (closes #152)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ convert_case = "0.6"
 criterion = { version = "0.5", features = ["html_reports"] }
 crossbeam = "0.8"
 cynic = { version = "3.7", features = ["http-reqwest"], default-features = false }
+daemonize-me = "2.0"
 darling = "0.20"
 dashmap = { version = "6.0", features = ["serde"] }
 default-test = "0.1"

--- a/config/logging.toml
+++ b/config/logging.toml
@@ -47,26 +47,10 @@ appenders = ["stdout", "file-application"]
 
 
 
-### Core
-
-[loggers."reactive_graph_frp"]
-level = "info"
+### Type System Implementation
 
 [loggers."reactive_graph_type_system_impl"]
 level = "debug"
-
-[loggers."reactive_graph_behaviour_service_impl"]
-level = "debug"
-
-[loggers."reactive_graph_plugin_service_impl"]
-level = "debug"
-
-[loggers."reactive_graph_dynamic_graph_impl"]
-level = "debug"
-
-
-
-### Type System Implementation
 
 [loggers."reactive_graph_type_system_impl::component_manager_impl"]
 level = "info"
@@ -96,6 +80,9 @@ level = "info"
 
 ### Behaviour Service Implementation
 
+[loggers."reactive_graph_behaviour_service_impl"]
+level = "debug"
+
 [loggers."reactive_graph_behaviour_service_impl::entity_behaviour_manager_impl"]
 level = "info"
 
@@ -124,6 +111,9 @@ level = "info"
 
 ### Dynamic Graph Impl
 
+[loggers."reactive_graph_dynamic_graph_impl"]
+level = "debug"
+
 [loggers."reactive_graph_dynamic_graph_impl::dynamic_graph_schema_manager_impl"]
 level = "info"
 
@@ -131,6 +121,9 @@ level = "info"
 level = "error"
 
 ### Plugin Service Implementation
+
+[loggers."reactive_graph_plugin_service_impl"]
+level = "debug"
 
 [loggers."reactive_graph_plugin_service_impl::plugin_container_manager_impl"]
 level = "info"
@@ -143,6 +136,17 @@ level = "info"
 
 [loggers."reactive_graph_plugin_service_impl::plugin_repository_manager_impl"]
 level = "info"
+
+### Runtime Implementation
+
+[loggers."reactive_graph_runtime_impl::runtime_impl"]
+level = "debug"
+
+### Reactive Graph FRP
+
+[loggers."reactive_graph_frp"]
+level = "info"
+
 
 
 

--- a/crates/reactive-graph/Cargo.toml
+++ b/crates/reactive-graph/Cargo.toml
@@ -62,6 +62,9 @@ reactive-graph-runtime-impl = { version = "0.10.0", path = "../runtime/impl", op
 reactive-graph-client = { version = "0.10.0", path = "../client", optional = true }
 reactive-graph-table-model = { version = "0.10.0", path = "../table-model", optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+daemonize-me = { workspace = true }
+
 [features]
 default = ["server", "client", "json5", "toml"]
 client = ["reactive-graph-client", "reactive-graph-table-model"]

--- a/crates/reactive-graph/src/main.rs
+++ b/crates/reactive-graph/src/main.rs
@@ -17,6 +17,17 @@ use crate::server::cli_args::Commands;
 #[cfg(feature = "server")]
 use crate::server::server;
 
+#[cfg(target_os = "linux")]
+use daemonize_me::Daemon;
+#[cfg(target_os = "linux")]
+use daemonize_me::Group;
+#[cfg(target_os = "linux")]
+use daemonize_me::User;
+#[cfg(target_os = "linux")]
+use std::any::Any;
+#[cfg(target_os = "linux")]
+use std::fs::File;
+
 #[cfg(feature = "client")]
 mod cli;
 #[cfg(feature = "server")]
@@ -25,11 +36,68 @@ mod server;
 #[global_allocator]
 static ALLOCATOR: System = System;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     #[cfg(feature = "server")]
     {}
     let cli_args = CliArguments::parse();
+
+    // Export CLI help as markdown
+    if cli_args.markdown_help {
+        clap_markdown::print_help_markdown::<CliArguments>();
+        exit(0);
+    }
+
+    // Initialize daemon
+    #[cfg(target_os = "linux")]
+    {
+        if cli_args.daemon {
+            let daemon = Daemon::new()
+                .work_dir(cli_args.daemon_working_directory.clone().unwrap_or(String::from(".")))
+                .setup_post_fork_parent_hook(post_fork_parent)
+                .setup_post_fork_child_hook(post_fork_child)
+                .setup_post_init_hook(after_init, None);
+            let daemon = match cli_args.daemon_name {
+                Some(ref daemon_name) => daemon.name(daemon_name.as_ref()),
+                None => daemon,
+            };
+            let daemon = match cli_args.daemon_pid {
+                Some(ref daemon_pid) => daemon.pid_file(daemon_pid, Some(false)),
+                None => daemon,
+            };
+            let daemon = match cli_args.daemon_stdout {
+                Some(ref daemon_stdout) => match File::create(daemon_stdout) {
+                    Ok(stdout) => daemon.stdout(stdout),
+                    Err(_) => daemon,
+                },
+                None => daemon,
+            };
+            let daemon = match cli_args.daemon_stderr {
+                Some(ref daemon_stderr) => match File::create(daemon_stderr) {
+                    Ok(stderr) => daemon.stderr(stderr),
+                    Err(_) => daemon,
+                },
+                None => daemon,
+            };
+            let daemon = if let (Some(ref daemon_user), Some(ref daemon_group)) = (cli_args.daemon_user.clone(), cli_args.daemon_group.clone()) {
+                if let (Ok(daemon_user), Ok(daemon_group)) = (User::try_from(daemon_user), Group::try_from(daemon_group)) {
+                    daemon.user(daemon_user).group(daemon_group)
+                } else {
+                    daemon
+                }
+            } else {
+                daemon
+            };
+
+            let daemon = daemon.start();
+            match daemon {
+                Ok(_) => println!("Process has been daemonized with success"),
+                Err(e) => {
+                    eprintln!("Failed to run as daemon: {}", e);
+                    exit(-1);
+                }
+            }
+        }
+    }
 
     // Initialize logging
     if !cli_args.quiet.unwrap_or(false) {
@@ -50,15 +118,41 @@ async fn main() {
             }
         }
     }
-    if cli_args.markdown_help {
-        clap_markdown::print_help_markdown::<CliArguments>();
-        exit(0);
-    }
+
+    tokio_main(cli_args)
+}
+
+#[tokio::main]
+async fn tokio_main(cli_args: CliArguments) {
     match cli_args.commands {
         Some(commands) => match commands {
             #[cfg(feature = "client")]
             Commands::Client(args) => client(args).await,
         },
-        None => server(cli_args).await,
+        None => {
+            #[cfg(feature = "server")]
+            {
+                server(cli_args).await
+            }
+        }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn post_fork_parent(_parent_pid: i32, _child_pid: i32) -> ! {
+    // println!("Exiting parent process. Parent PID: {}, Child PID {}", parent_pid, child_pid);
+    exit(0);
+}
+
+#[cfg(target_os = "linux")]
+fn post_fork_child(_parent_pid: i32, _child_pid: i32) {
+    // println!("Forked into child process. Parent PID: {}, Child PID {}", parent_pid, child_pid);
+    // Child hook must return
+    return;
+}
+
+#[cfg(target_os = "linux")]
+fn after_init(_: Option<&dyn Any>) {
+    // println!("Daemon has been initialized");
+    return;
 }

--- a/crates/reactive-graph/src/server/cli_args.rs
+++ b/crates/reactive-graph/src/server/cli_args.rs
@@ -61,7 +61,7 @@ pub struct CliArguments {
     /// Timeout for graceful workers shutdown in seconds.
     /// After receiving a stop signal, workers have this much time to finish serving requests.
     /// Workers still alive after the timeout are force dropped.
-    /// By default shutdown timeout sets to 30 seconds.
+    /// By default, shutdown timeout sets to 30 seconds.
     #[arg(long, env = "REACTIVE_GRAPH_INSTANCE_SHUTDOWN_TIMEOUT")]
     pub(crate) shutdown_timeout: Option<u64>,
 
@@ -110,6 +110,49 @@ pub struct CliArguments {
     /// If true, generates command line documentation.
     #[arg(long, hide = true)]
     pub(crate) markdown_help: bool,
+
+    /// If true, the process will run as daemon.
+    #[cfg(target_os = "linux")]
+    #[arg(short = 'D', long, env = "REACTIVE_GRAPH_DAEMON")]
+    pub(crate) daemon: bool,
+
+    /// Sets the name of the daemon.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_NAME")]
+    pub(crate) daemon_name: Option<String>,
+
+    /// The location of the daemon PID file.
+    /// By default, no PID file will be created.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_PID")]
+    pub(crate) daemon_pid: Option<String>,
+
+    /// The working directory of the daemon.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_WORKING_DIRECTORY")]
+    pub(crate) daemon_working_directory: Option<String>,
+
+    /// Stdout will be written into this file.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_STDOUT")]
+    pub(crate) daemon_stdout: Option<String>,
+
+    /// Stderr will be written into this file.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_STDERR")]
+    pub(crate) daemon_stderr: Option<String>,
+
+    /// If set will drop privileges to the specified user.
+    /// Note: Both must be given: user and group.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_USER")]
+    pub(crate) daemon_user: Option<String>,
+
+    /// If set will drop privileges to the specified group.
+    /// Note: Both must be given: user and group.
+    #[cfg(target_os = "linux")]
+    #[arg(long, env = "REACTIVE_GRAPH_DAEMON_GROUP")]
+    pub(crate) daemon_group: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]


### PR DESCRIPTION
### Summary

On Linux, it's now possible to start the process and run it in the background. Because the daemon has no stdout and stderr, a file can be given as output. Also, the process can drop privileges to a given user+group. Optionally, a PID and name can be specified.

### Command Line Arguments

```
$ reactive-graph --help
  -D, --daemon
          If true, the process will run as daemon [env: REACTIVE_GRAPH_DAEMON=]
      --daemon-name <DAEMON_NAME>
          Sets the name of the daemon [env: REACTIVE_GRAPH_DAEMON_NAME=]
      --daemon-pid <DAEMON_PID>
          The location of the daemon PID file. By default, no PID file will be created [env: REACTIVE_GRAPH_DAEMON_PID=]
      --daemon-working-directory <DAEMON_WORKING_DIRECTORY>
          The working directory of the daemon [env: REACTIVE_GRAPH_DAEMON_WORKING_DIRECTORY=]
      --daemon-stdout <DAEMON_STDOUT>
          Stdout will be written into this file [env: REACTIVE_GRAPH_DAEMON_STDOUT=]
      --daemon-stderr <DAEMON_STDERR>
          Stderr will be written into this file [env: REACTIVE_GRAPH_DAEMON_STDERR=]
      --daemon-user <DAEMON_USER>
          If set will drop privileges to the specified user. Note: Both must be given: user and group [env: REACTIVE_GRAPH_DAEMON_USER=]
      --daemon-group <DAEMON_GROUP>
          If set will drop privileges to the specified group. Note: Both must be given: user and group [env: REACTIVE_GRAPH_DAEMON_GROUP=]
```