### PR TITLE
Shell Completions and Man Pages

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Run cargo-tarpaulin
         run: cargo +nightly tarpaulin --engine llvm --verbose --all-features --workspace --timeout 120 --out xml
       # Note: closed-source code needs to provide a token,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Run cargo doc
         run: cargo doc --all --no-deps
       - name: Deploy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
       - "crates/**/*.rs"
       - "crates/**/Cargo.toml"
       - "Cargo.toml"
+      - "CHANGELOG.md"
       - ".github/workflows/rust.yml"
   pull_request:
     branches: [ main ]
@@ -14,6 +15,7 @@ on:
       - "crates/**/*.rs"
       - "crates/**/Cargo.toml"
       - "Cargo.toml"
+      - "CHANGELOG.md"
       - ".github/workflows/rust.yml"
 
 env:
@@ -58,9 +60,16 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: Run cargo clippy
         run: cargo clippy
+  check_changelog:
+    name: Check Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: CHANGELOG.md
   build:
     name: Release Build
-    needs: [ formatting, lint ]
+    needs: [ formatting, lint, check_changelog ]
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -81,7 +90,7 @@ jobs:
         run: cargo build --release --verbose
   test:
     name: Tests
-    needs: [ formatting, lint ]
+    needs: [ formatting, lint, check_changelog ]
     strategy:
       matrix:
         toolchain: [ stable, nightly-2024-08-19 ]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Run cargo clippy
         run: cargo clippy
   build:
@@ -76,7 +76,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Build (Release Mode)
         run: cargo build --release --verbose
   test:
@@ -104,6 +104,6 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.5
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Test (Release Mode)
         run: cargo test --release --verbose --target ${{ matrix.target }}

--- a/.run/Integration Tests.run.xml
+++ b/.run/Integration Tests.run.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration Tests" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="test --features integration-tests" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs>
+      <env name="RUSTC_WRAPPER" value="sccache" />
+    </envs>
+    <option name="emulateTerminal" value="false" />
+    <option name="channel" value="NIGHTLY" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="FULL" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0-2] - 2024-09-27
+
+### Added
+
+- CLI: Print or install shell completions (bash, fish, zsh, powershell) and man pages
+
 ## [0.10.0-1] - 2024-03-24
 
 This is a highly technical release with a lot of major refactorings and design changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We want to make contributing to this project as easy and transparent as possible
 ## First Steps
 
 If you're new, we encourage you to take a look at issues tagged
-with [good first issue](https://github.com/reactive-graph/plugins-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+with [good first issue](https://github.com/reactive-graph/reactive-graph/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 ## Social Media
 
@@ -14,7 +14,8 @@ Join our [Discord server](https://discord.gg/KQgk5CmZQn) or follow us at [Mastod
 
 ## Code of Conduct
 
-Please review our [Code of Conduct](https://github.com/reactive-graph/plugins-core/blob/main/CODE_OF_CONDUCT.md). It is in effect at all times. We expect it to
+Please review our [Code of Conduct](https://github.com/reactive-graph/reactive-graph/blob/main/CODE_OF_CONDUCT.md). It is in effect at all times. We expect it
+to
 be honored by everyone who contributes to this project.
 
 ## Opening an Issue
@@ -23,7 +24,7 @@ Before creating an issue, check if you are using the latest version of the proje
 
 ## Reporting Security Issues
 
-Review our [Security Policy](https://github.com/reactive-graph/plugins-core/blob/main/SECURITY.md). Do not file a public issue for security vulnerabilities.
+Review our [Security Policy](https://github.com/reactive-graph/reactive-graph/blob/main/SECURITY.md). Do not file a public issue for security vulnerabilities.
 
 ## Bug Reports and Other Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,120 @@
 # Contributing
 
-We are always open for suggestions or pull requests. You can search after ``diff:first issue`` for good issues to get
-in touch with this project.
+We want to make contributing to this project as easy and transparent as possible.
 
-Join our `Discord server <https://discord.gg/acUW8k7>`__.
+## First Steps
 
-`Hanack <https://github.com/aschaeffer>`__
-    - Large portion of entity system.
+If you're new, we encourage you to take a look at issues tagged
+with [good first issue](https://github.com/reactive-graph/plugins-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
-`IAmNotHanni <https://github.com/IAmNotHanni>`__
-    - Project and community management.
-    - Large portion of Vulkan renderer.
+## Social Media
+
+Join our [Discord server](https://discord.gg/KQgk5CmZQn) or follow us at [Mastodon](https://floss.social/@reactive_graph),
+[Youtube](https://www.youtube.com/@reactive-graph) or [Facebook](https://www.facebook.com/reactive.graph).
+
+## Code of Conduct
+
+Please review our [Code of Conduct](https://github.com/reactive-graph/plugins-core/blob/main/CODE_OF_CONDUCT.md). It is in effect at all times. We expect it to
+be honored by everyone who contributes to this project.
+
+## Opening an Issue
+
+Before creating an issue, check if you are using the latest version of the project. If you are not up-to-date, see if updating fixes your issue first.
+
+## Reporting Security Issues
+
+Review our [Security Policy](https://github.com/reactive-graph/plugins-core/blob/main/SECURITY.md). Do not file a public issue for security vulnerabilities.
+
+## Bug Reports and Other Issues
+
+A great way to contribute to the project is to send a detailed issue when you encounter a problem. We always appreciate a well-written, thorough bug report.
+
+In short, since you are most likely a developer, **provide a ticket that you would like to receive**.
+
+- **Do not open a duplicate issue!** Search through existing issues to see if your issue has previously been reported. If your issue exists, comment with any
+  additional information you have. You may simply note "I have this problem too", which helps prioritize the most common problems and requests.
+
+- **Prefer using [reactions](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)**, not comments, if you simply want to "+1" an
+  existing issue.
+
+- **Fully complete the provided issue template.** The bug report template requests all the information we need to quickly and efficiently address your issue. Be
+  clear, concise, and descriptive. Provide as much information as you can, including steps to reproduce, stack traces, compiler errors, library versions, OS
+  versions, and screenshots (if applicable).
+
+- **Use [GitHub-flavored Markdown](https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax).** Especially put code blocks and
+  console outputs in backticks (```). This improves readability.
+
+## Feature Requests
+
+Feature requests are welcome! While we will consider all requests, we cannot guarantee your request will be accepted. Your idea may be great, but also
+out-of-scope for the project. If accepted, we cannot make any commitments regarding the timeline for implementation and release. However, you are welcome to
+submit a pull request to help!
+
+- **Do not open a duplicate feature request.** Search for existing feature requests first. If you find your feature (or one very similar) previously requested,
+  comment on that issue.
+
+- Be precise about the proposed outcome of the feature and how it relates to existing features. Include implementation details if possible.
+
+## Triaging Issues
+
+You can triage issues which may include reproducing bug reports or asking for additional information, such as version numbers or reproduction instructions. Any
+help you can provide to quickly resolve an issue is very much appreciated!
+
+## Submitting Pull Requests
+
+We **love** pull requests! Before [forking the repo](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
+and [creating a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests)
+for non-trivial changes, it is usually best to first open an issue to discuss the changes, or discuss your intended approach for solving the problem in the
+comments for an existing issue.
+
+For most contributions, after your first pull request is accepted and merged, you will
+be [invited to the project](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/inviting-collaborators-to-a-personal-repository)
+and given **push access**.
+
+*Note: All contributions will be licensed under the project's license.*
+
+- **Smaller is better.** Submit **one** pull request per bug fix or feature. A pull request should contain isolated changes pertaining to a single bug fix or
+  feature implementation. **Do not** refactor or reformat code that is unrelated to your change. It is better to **submit many small pull requests** rather than
+  a single large one. Enormous pull requests will take enormous amounts of time to review, or may be rejected altogether.
+
+- **Coordinate bigger changes.** For large and non-trivial changes, open an issue to discuss a strategy with the maintainers. Otherwise, you risk doing a lot of
+  work for nothing!
+
+- **Prioritize understanding over cleverness.** Write code clearly and concisely. Remember that source code usually gets written once and read often. Ensure the
+  code is clear to the reader. The purpose and logic should be obvious to a reasonably skilled developer, otherwise you should add a comment that explains it.
+
+- **Follow existing coding style and conventions.** Keep your code consistent with the style, formatting, and conventions in the rest of the code base. When
+  possible, these will be enforced with a linter. Consistency makes it easier to review and modify in the future.
+
+- **Include test coverage.** Add unit tests when possible. Follow existing patterns for implementing tests.
+
+- **Add documentation.** Document your changes with code doc comments or in existing guides.
+
+- **Update the CHANGELOG** for all enhancements and bug fixes.
+
+- **Use the repo's default branch.** Branch from
+  and [submit your pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) to the
+  repo's default branch (`main`).
+
+- **[Resolve any merge conflicts](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/resolving-a-merge-conflict-on-github)** that
+  occur.
+
+- **Promptly address any CI failures**. If your pull request fails to build or pass tests, please push another commit to fix it.
+
+## Code Review
+
+- **Review the code, not the author.** Look for and suggest improvements without disparaging or insulting the author. Provide actionable feedback and explain
+  your reasoning.
+
+- **You are not your code.** When your code is critiqued, questioned, or constructively criticized, remember that you are not your code. Do not take code review
+  personally.
+
+- **Always do your best.** No one writes bugs on purpose. Do your best, and learn from your mistakes.
+
+- Kindly note any violations to the guidelines specified in this document.
+
+## Coding Style
+
+Consistency is the most important. Following the existing style, formatting, and naming conventions of the file you are modifying and of the overall project.
+Failure to do so will result in a prolonged review process that has to focus on updating the superficial aspects of your code, rather than improving its
+functionality and performance. Style and format will be enforced with a linter.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,8 @@ async-trait = "0.1"
 async-std = { version = "1.10", features = ["attributes", "tokio1"] }
 aws-lc-rs = { version = "1.9.0", features = ["prebuilt-nasm"] }
 clap = { version = "4.1", features = ["derive", "env"] }
+clap_complete = "4.5"
+clap_mangen = "0.2"
 clap-markdown = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 colored = "2.0"
@@ -168,6 +170,7 @@ uuid = { version = "1.4", features = ["serde", "v4"] }
 vergen = { version = "8.2" }
 walkdir = "2.3"
 wildmatch = "2.1"
+xdg = "2.4"
 
 [profile.dev]
 opt-level = 0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+If you discover a security issue, please bring it to our attention right away!
+
+## Reporting a Vulnerability
+
+Please **DO NOT** file a public issue to report a security vulnerability, instead send your report privately to **info@reactive-graph.io**. This will help
+ensure that any vulnerabilities that are found can be [disclosed responsibly](https://en.wikipedia.org/wiki/Responsible_disclosure) to any affected parties.
+
+## Supported Versions
+
+Project versions that are currently being supported with security updates vary per project.
+Please see specific project repositories for details.
+If nothing is specified, only the latest major versions are supported.

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -29,6 +29,10 @@ reactive-graph-runtime-impl = { version = "0.10.0", path = "../runtime/impl" }
 reactive-graph-table-model = { version = "0.10.0", path = "../table-model" }
 tokio = { workspace = true, features = ["macros", "time", "rt", "rt-multi-thread", "test-util"] }
 
+[features]
+default = []
+integration-tests = []
+
 [lib]
 crate-type = ["lib"]
 

--- a/crates/client/src/client/plugin/queries/get_all.rs
+++ b/crates/client/src/client/plugin/queries/get_all.rs
@@ -14,12 +14,14 @@ pub mod queries {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 pub mod test {
     use crate::ReactiveGraphClient;
     use reactive_graph_runtime_api::Runtime;
     use reactive_graph_runtime_impl::RuntimeBuilder;
     use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_all_plugins() {
@@ -34,6 +36,8 @@ pub mod test {
             .spawn()
             .await
             .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+                sleep(Duration::from_millis(2000)).await;
+
                 let plugin_container_manager = runtime.get_plugin_container_manager();
                 assert_eq!(plugin_container_manager.get_plugins().len(), 0);
 

--- a/crates/client/src/client/runtime/instance/queries/get_instance_info.rs
+++ b/crates/client/src/client/runtime/instance/queries/get_instance_info.rs
@@ -14,12 +14,14 @@ pub mod queries {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 pub mod test {
     use crate::ReactiveGraphClient;
     use reactive_graph_runtime_api::Runtime;
     use reactive_graph_runtime_impl::RuntimeBuilder;
     use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_instance_info() {
@@ -36,6 +38,8 @@ pub mod test {
             .spawn()
             .await
             .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+                sleep(Duration::from_millis(2000)).await;
+
                 // Get instance info from the runtime
                 let rt_instance_info = runtime.get_instance_service().get_instance_info();
                 let rt_address = rt_instance_info.address();

--- a/crates/client/src/client/runtime/remotes/mutations/add_remote.rs
+++ b/crates/client/src/client/runtime/remotes/mutations/add_remote.rs
@@ -23,12 +23,14 @@ pub mod mutations {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 pub mod test {
     use crate::ReactiveGraphClient;
     use reactive_graph_runtime_api::Runtime;
     use reactive_graph_runtime_impl::RuntimeBuilder;
     use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_remote() {
@@ -43,6 +45,8 @@ pub mod test {
             .spawn()
             .await
             .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+                sleep(Duration::from_millis(2000)).await;
+
                 let remotes_manager = runtime.get_remotes_manager();
 
                 // Get instance info from the runtime

--- a/crates/client/src/client/runtime/remotes/queries/get_all.rs
+++ b/crates/client/src/client/runtime/remotes/queries/get_all.rs
@@ -14,12 +14,14 @@ pub mod queries {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 pub mod test {
     use crate::ReactiveGraphClient;
     use reactive_graph_runtime_api::Runtime;
     use reactive_graph_runtime_impl::RuntimeBuilder;
     use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_all_remotes() {
@@ -34,6 +36,8 @@ pub mod test {
             .spawn()
             .await
             .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+                sleep(Duration::from_millis(2000)).await;
+
                 let remotes_manager = runtime.get_remotes_manager();
 
                 let rt_address = runtime.address();

--- a/crates/client/src/client/runtime/shutdown/mutations/shutdown.rs
+++ b/crates/client/src/client/runtime/shutdown/mutations/shutdown.rs
@@ -12,13 +12,13 @@ pub mod mutations {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 pub mod test {
-    use std::sync::Arc;
-    use std::time::Duration;
-
     use reactive_graph_runtime_api::Runtime;
     use reactive_graph_runtime_impl::RuntimeBuilder;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::sleep;
 
     use crate::ReactiveGraphClient;
 
@@ -35,6 +35,8 @@ pub mod test {
             .spawn()
             .await
             .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+                sleep(Duration::from_millis(2000)).await;
+
                 let count_before = Arc::strong_count(&runtime);
 
                 // Check that the shutdown manager is not shutting down and the runtime is in running state

--- a/crates/client/src/client/types/components/get_by_type.rs
+++ b/crates/client/src/client/types/components/get_by_type.rs
@@ -32,7 +32,7 @@ pub mod queries {
         GetComponentByType::build(ty.clone().into())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "integration-tests"))]
     mod tests {
         use reactive_graph_runtime_impl::RuntimeBuilder;
 

--- a/crates/client/src/client/types/entities/get_all.rs
+++ b/crates/client/src/client/types/entities/get_all.rs
@@ -22,7 +22,7 @@ pub mod queries {
         GetAllEntityTypes::build(())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "integration-tests"))]
     mod tests {
         use reactive_graph_runtime_impl::RuntimeBuilder;
 

--- a/crates/client/src/client/types/entities/get_by_type.rs
+++ b/crates/client/src/client/types/entities/get_by_type.rs
@@ -32,7 +32,7 @@ pub mod queries {
         GetEntityTypeByType::build(ty.clone().into())
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "integration-tests"))]
     mod tests {
         use reactive_graph_runtime_impl::RuntimeBuilder;
 

--- a/crates/reactive-graph/Cargo.toml
+++ b/crates/reactive-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive-graph"
-description = "Reactive Graph Flow"
+description = "Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -8,6 +8,8 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 readme = "../../README.md"
+
+keywords = ["reactive", "runtime", "graph", "control-flow"]
 
 [package.metadata.deb]
 name = "reactive-graph"
@@ -25,6 +27,10 @@ assets = [
     ["debian/etc/reactive-graph/instance.toml", "etc/reactive-graph/default/instance.toml", "644"],
     ["debian/etc/reactive-graph/logging.toml", "etc/reactive-graph/default/logging.toml", "644"],
     ["debian/etc/reactive-graph/plugins.toml", "etc/reactive-graph/default/plugins.toml", "644"],
+    ["debian/usr/share/bash-completion/completions/reactive-graph", "usr/share/bash-completion/completions/reactive-graph", "644"],
+    ["debian/usr/share/bash-completion/completions/reactive-graph-client", "usr/share/bash-completion/completions/reactive-graph-client", "644"],
+    ["debian/usr/share/zsh/functions/Completion/Base/_reactive-graph", "usr/share/zsh/functions/Completion/Base/_reactive-graph", "644"],
+    ["debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-client", "usr/share/zsh/functions/Completion/Base/_reactive-graph-client", "644"],
     ["debian/usr/share/reactive-graph/plugins/deploy/.gitkeep", "usr/share/reactive-graph/default/plugins/deploy/.gitkeep", "644"],
     ["debian/usr/share/reactive-graph/plugins/installed/.gitkeep", "usr/share/reactive-graph/default/plugins/installed/.gitkeep", "644"],
     ["debian/var/lib/reactive-graph/repositories/flows/.gitkeep", "var/lib/reactive-graph/default/repositories/flows/.gitkeep", "644"],
@@ -39,6 +45,7 @@ restart-after-upgrade = true
 actix-web = { workspace = true, features = ["rustls-0_23"] }
 clap = { workspace = true, features = ["derive", "env"] }
 clap-markdown = { workspace = true }
+clap_complete = { workspace = true }
 colored = { workspace = true }
 json5 = { workspace = true, optional = true }
 log = { workspace = true, features = ["std", "serde"] }
@@ -64,7 +71,9 @@ reactive-graph-client = { version = "0.10.0", path = "../client", optional = tru
 reactive-graph-table-model = { version = "0.10.0", path = "../table-model", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+clap_mangen = { workspace = true }
 daemonize-me = { workspace = true }
+xdg = { workspace = true }
 
 [features]
 default = ["server", "client", "json5", "toml"]

--- a/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph
+++ b/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph
@@ -1,0 +1,7566 @@
+_reactive-graph() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd=""
+    opts=""
+
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="reactive__graph"
+                ;;
+            reactive__graph,client)
+                cmd="reactive__graph__client"
+                ;;
+            reactive__graph,help)
+                cmd="reactive__graph__help"
+                ;;
+            reactive__graph__client,components)
+                cmd="reactive__graph__client__components"
+                ;;
+            reactive__graph__client,entity-instances)
+                cmd="reactive__graph__client__entity__instances"
+                ;;
+            reactive__graph__client,entity-types)
+                cmd="reactive__graph__client__entity__types"
+                ;;
+            reactive__graph__client,execute-command)
+                cmd="reactive__graph__client__execute__command"
+                ;;
+            reactive__graph__client,help)
+                cmd="reactive__graph__client__help"
+                ;;
+            reactive__graph__client,instance-info)
+                cmd="reactive__graph__client__instance__info"
+                ;;
+            reactive__graph__client,plugins)
+                cmd="reactive__graph__client__plugins"
+                ;;
+            reactive__graph__client,relation-instances)
+                cmd="reactive__graph__client__relation__instances"
+                ;;
+            reactive__graph__client,relation-types)
+                cmd="reactive__graph__client__relation__types"
+                ;;
+            reactive__graph__client,remotes)
+                cmd="reactive__graph__client__remotes"
+                ;;
+            reactive__graph__client,shutdown)
+                cmd="reactive__graph__client__shutdown"
+                ;;
+            reactive__graph__client__components,add-extension)
+                cmd="reactive__graph__client__components__add__extension"
+                ;;
+            reactive__graph__client__components,add-property)
+                cmd="reactive__graph__client__components__add__property"
+                ;;
+            reactive__graph__client__components,create)
+                cmd="reactive__graph__client__components__create"
+                ;;
+            reactive__graph__client__components,delete)
+                cmd="reactive__graph__client__components__delete"
+                ;;
+            reactive__graph__client__components,get)
+                cmd="reactive__graph__client__components__get"
+                ;;
+            reactive__graph__client__components,help)
+                cmd="reactive__graph__client__components__help"
+                ;;
+            reactive__graph__client__components,list)
+                cmd="reactive__graph__client__components__list"
+                ;;
+            reactive__graph__client__components,list-extensions)
+                cmd="reactive__graph__client__components__list__extensions"
+                ;;
+            reactive__graph__client__components,list-properties)
+                cmd="reactive__graph__client__components__list__properties"
+                ;;
+            reactive__graph__client__components,remove-extension)
+                cmd="reactive__graph__client__components__remove__extension"
+                ;;
+            reactive__graph__client__components,remove-property)
+                cmd="reactive__graph__client__components__remove__property"
+                ;;
+            reactive__graph__client__components,update-description)
+                cmd="reactive__graph__client__components__update__description"
+                ;;
+            reactive__graph__client__components__help,add-extension)
+                cmd="reactive__graph__client__components__help__add__extension"
+                ;;
+            reactive__graph__client__components__help,add-property)
+                cmd="reactive__graph__client__components__help__add__property"
+                ;;
+            reactive__graph__client__components__help,create)
+                cmd="reactive__graph__client__components__help__create"
+                ;;
+            reactive__graph__client__components__help,delete)
+                cmd="reactive__graph__client__components__help__delete"
+                ;;
+            reactive__graph__client__components__help,get)
+                cmd="reactive__graph__client__components__help__get"
+                ;;
+            reactive__graph__client__components__help,help)
+                cmd="reactive__graph__client__components__help__help"
+                ;;
+            reactive__graph__client__components__help,list)
+                cmd="reactive__graph__client__components__help__list"
+                ;;
+            reactive__graph__client__components__help,list-extensions)
+                cmd="reactive__graph__client__components__help__list__extensions"
+                ;;
+            reactive__graph__client__components__help,list-properties)
+                cmd="reactive__graph__client__components__help__list__properties"
+                ;;
+            reactive__graph__client__components__help,remove-extension)
+                cmd="reactive__graph__client__components__help__remove__extension"
+                ;;
+            reactive__graph__client__components__help,remove-property)
+                cmd="reactive__graph__client__components__help__remove__property"
+                ;;
+            reactive__graph__client__components__help,update-description)
+                cmd="reactive__graph__client__components__help__update__description"
+                ;;
+            reactive__graph__client__entity__instances,add-component)
+                cmd="reactive__graph__client__entity__instances__add__component"
+                ;;
+            reactive__graph__client__entity__instances,add-property)
+                cmd="reactive__graph__client__entity__instances__add__property"
+                ;;
+            reactive__graph__client__entity__instances,create)
+                cmd="reactive__graph__client__entity__instances__create"
+                ;;
+            reactive__graph__client__entity__instances,delete)
+                cmd="reactive__graph__client__entity__instances__delete"
+                ;;
+            reactive__graph__client__entity__instances,get)
+                cmd="reactive__graph__client__entity__instances__get"
+                ;;
+            reactive__graph__client__entity__instances,get-by-label)
+                cmd="reactive__graph__client__entity__instances__get__by__label"
+                ;;
+            reactive__graph__client__entity__instances,get-property)
+                cmd="reactive__graph__client__entity__instances__get__property"
+                ;;
+            reactive__graph__client__entity__instances,help)
+                cmd="reactive__graph__client__entity__instances__help"
+                ;;
+            reactive__graph__client__entity__instances,list)
+                cmd="reactive__graph__client__entity__instances__list"
+                ;;
+            reactive__graph__client__entity__instances,list-components)
+                cmd="reactive__graph__client__entity__instances__list__components"
+                ;;
+            reactive__graph__client__entity__instances,list-properties)
+                cmd="reactive__graph__client__entity__instances__list__properties"
+                ;;
+            reactive__graph__client__entity__instances,remove-component)
+                cmd="reactive__graph__client__entity__instances__remove__component"
+                ;;
+            reactive__graph__client__entity__instances,remove-property)
+                cmd="reactive__graph__client__entity__instances__remove__property"
+                ;;
+            reactive__graph__client__entity__instances,set-property)
+                cmd="reactive__graph__client__entity__instances__set__property"
+                ;;
+            reactive__graph__client__entity__instances__help,add-component)
+                cmd="reactive__graph__client__entity__instances__help__add__component"
+                ;;
+            reactive__graph__client__entity__instances__help,add-property)
+                cmd="reactive__graph__client__entity__instances__help__add__property"
+                ;;
+            reactive__graph__client__entity__instances__help,create)
+                cmd="reactive__graph__client__entity__instances__help__create"
+                ;;
+            reactive__graph__client__entity__instances__help,delete)
+                cmd="reactive__graph__client__entity__instances__help__delete"
+                ;;
+            reactive__graph__client__entity__instances__help,get)
+                cmd="reactive__graph__client__entity__instances__help__get"
+                ;;
+            reactive__graph__client__entity__instances__help,get-by-label)
+                cmd="reactive__graph__client__entity__instances__help__get__by__label"
+                ;;
+            reactive__graph__client__entity__instances__help,get-property)
+                cmd="reactive__graph__client__entity__instances__help__get__property"
+                ;;
+            reactive__graph__client__entity__instances__help,help)
+                cmd="reactive__graph__client__entity__instances__help__help"
+                ;;
+            reactive__graph__client__entity__instances__help,list)
+                cmd="reactive__graph__client__entity__instances__help__list"
+                ;;
+            reactive__graph__client__entity__instances__help,list-components)
+                cmd="reactive__graph__client__entity__instances__help__list__components"
+                ;;
+            reactive__graph__client__entity__instances__help,list-properties)
+                cmd="reactive__graph__client__entity__instances__help__list__properties"
+                ;;
+            reactive__graph__client__entity__instances__help,remove-component)
+                cmd="reactive__graph__client__entity__instances__help__remove__component"
+                ;;
+            reactive__graph__client__entity__instances__help,remove-property)
+                cmd="reactive__graph__client__entity__instances__help__remove__property"
+                ;;
+            reactive__graph__client__entity__instances__help,set-property)
+                cmd="reactive__graph__client__entity__instances__help__set__property"
+                ;;
+            reactive__graph__client__entity__types,add-component)
+                cmd="reactive__graph__client__entity__types__add__component"
+                ;;
+            reactive__graph__client__entity__types,add-extension)
+                cmd="reactive__graph__client__entity__types__add__extension"
+                ;;
+            reactive__graph__client__entity__types,add-property)
+                cmd="reactive__graph__client__entity__types__add__property"
+                ;;
+            reactive__graph__client__entity__types,create)
+                cmd="reactive__graph__client__entity__types__create"
+                ;;
+            reactive__graph__client__entity__types,delete)
+                cmd="reactive__graph__client__entity__types__delete"
+                ;;
+            reactive__graph__client__entity__types,get)
+                cmd="reactive__graph__client__entity__types__get"
+                ;;
+            reactive__graph__client__entity__types,help)
+                cmd="reactive__graph__client__entity__types__help"
+                ;;
+            reactive__graph__client__entity__types,list)
+                cmd="reactive__graph__client__entity__types__list"
+                ;;
+            reactive__graph__client__entity__types,list-components)
+                cmd="reactive__graph__client__entity__types__list__components"
+                ;;
+            reactive__graph__client__entity__types,list-extensions)
+                cmd="reactive__graph__client__entity__types__list__extensions"
+                ;;
+            reactive__graph__client__entity__types,list-properties)
+                cmd="reactive__graph__client__entity__types__list__properties"
+                ;;
+            reactive__graph__client__entity__types,remove-component)
+                cmd="reactive__graph__client__entity__types__remove__component"
+                ;;
+            reactive__graph__client__entity__types,remove-extension)
+                cmd="reactive__graph__client__entity__types__remove__extension"
+                ;;
+            reactive__graph__client__entity__types,remove-property)
+                cmd="reactive__graph__client__entity__types__remove__property"
+                ;;
+            reactive__graph__client__entity__types,update-description)
+                cmd="reactive__graph__client__entity__types__update__description"
+                ;;
+            reactive__graph__client__entity__types__help,add-component)
+                cmd="reactive__graph__client__entity__types__help__add__component"
+                ;;
+            reactive__graph__client__entity__types__help,add-extension)
+                cmd="reactive__graph__client__entity__types__help__add__extension"
+                ;;
+            reactive__graph__client__entity__types__help,add-property)
+                cmd="reactive__graph__client__entity__types__help__add__property"
+                ;;
+            reactive__graph__client__entity__types__help,create)
+                cmd="reactive__graph__client__entity__types__help__create"
+                ;;
+            reactive__graph__client__entity__types__help,delete)
+                cmd="reactive__graph__client__entity__types__help__delete"
+                ;;
+            reactive__graph__client__entity__types__help,get)
+                cmd="reactive__graph__client__entity__types__help__get"
+                ;;
+            reactive__graph__client__entity__types__help,help)
+                cmd="reactive__graph__client__entity__types__help__help"
+                ;;
+            reactive__graph__client__entity__types__help,list)
+                cmd="reactive__graph__client__entity__types__help__list"
+                ;;
+            reactive__graph__client__entity__types__help,list-components)
+                cmd="reactive__graph__client__entity__types__help__list__components"
+                ;;
+            reactive__graph__client__entity__types__help,list-extensions)
+                cmd="reactive__graph__client__entity__types__help__list__extensions"
+                ;;
+            reactive__graph__client__entity__types__help,list-properties)
+                cmd="reactive__graph__client__entity__types__help__list__properties"
+                ;;
+            reactive__graph__client__entity__types__help,remove-component)
+                cmd="reactive__graph__client__entity__types__help__remove__component"
+                ;;
+            reactive__graph__client__entity__types__help,remove-extension)
+                cmd="reactive__graph__client__entity__types__help__remove__extension"
+                ;;
+            reactive__graph__client__entity__types__help,remove-property)
+                cmd="reactive__graph__client__entity__types__help__remove__property"
+                ;;
+            reactive__graph__client__entity__types__help,update-description)
+                cmd="reactive__graph__client__entity__types__help__update__description"
+                ;;
+            reactive__graph__client__help,components)
+                cmd="reactive__graph__client__help__components"
+                ;;
+            reactive__graph__client__help,entity-instances)
+                cmd="reactive__graph__client__help__entity__instances"
+                ;;
+            reactive__graph__client__help,entity-types)
+                cmd="reactive__graph__client__help__entity__types"
+                ;;
+            reactive__graph__client__help,execute-command)
+                cmd="reactive__graph__client__help__execute__command"
+                ;;
+            reactive__graph__client__help,help)
+                cmd="reactive__graph__client__help__help"
+                ;;
+            reactive__graph__client__help,instance-info)
+                cmd="reactive__graph__client__help__instance__info"
+                ;;
+            reactive__graph__client__help,plugins)
+                cmd="reactive__graph__client__help__plugins"
+                ;;
+            reactive__graph__client__help,relation-instances)
+                cmd="reactive__graph__client__help__relation__instances"
+                ;;
+            reactive__graph__client__help,relation-types)
+                cmd="reactive__graph__client__help__relation__types"
+                ;;
+            reactive__graph__client__help,remotes)
+                cmd="reactive__graph__client__help__remotes"
+                ;;
+            reactive__graph__client__help,shutdown)
+                cmd="reactive__graph__client__help__shutdown"
+                ;;
+            reactive__graph__client__help__components,add-extension)
+                cmd="reactive__graph__client__help__components__add__extension"
+                ;;
+            reactive__graph__client__help__components,add-property)
+                cmd="reactive__graph__client__help__components__add__property"
+                ;;
+            reactive__graph__client__help__components,create)
+                cmd="reactive__graph__client__help__components__create"
+                ;;
+            reactive__graph__client__help__components,delete)
+                cmd="reactive__graph__client__help__components__delete"
+                ;;
+            reactive__graph__client__help__components,get)
+                cmd="reactive__graph__client__help__components__get"
+                ;;
+            reactive__graph__client__help__components,list)
+                cmd="reactive__graph__client__help__components__list"
+                ;;
+            reactive__graph__client__help__components,list-extensions)
+                cmd="reactive__graph__client__help__components__list__extensions"
+                ;;
+            reactive__graph__client__help__components,list-properties)
+                cmd="reactive__graph__client__help__components__list__properties"
+                ;;
+            reactive__graph__client__help__components,remove-extension)
+                cmd="reactive__graph__client__help__components__remove__extension"
+                ;;
+            reactive__graph__client__help__components,remove-property)
+                cmd="reactive__graph__client__help__components__remove__property"
+                ;;
+            reactive__graph__client__help__components,update-description)
+                cmd="reactive__graph__client__help__components__update__description"
+                ;;
+            reactive__graph__client__help__entity__instances,add-component)
+                cmd="reactive__graph__client__help__entity__instances__add__component"
+                ;;
+            reactive__graph__client__help__entity__instances,add-property)
+                cmd="reactive__graph__client__help__entity__instances__add__property"
+                ;;
+            reactive__graph__client__help__entity__instances,create)
+                cmd="reactive__graph__client__help__entity__instances__create"
+                ;;
+            reactive__graph__client__help__entity__instances,delete)
+                cmd="reactive__graph__client__help__entity__instances__delete"
+                ;;
+            reactive__graph__client__help__entity__instances,get)
+                cmd="reactive__graph__client__help__entity__instances__get"
+                ;;
+            reactive__graph__client__help__entity__instances,get-by-label)
+                cmd="reactive__graph__client__help__entity__instances__get__by__label"
+                ;;
+            reactive__graph__client__help__entity__instances,get-property)
+                cmd="reactive__graph__client__help__entity__instances__get__property"
+                ;;
+            reactive__graph__client__help__entity__instances,list)
+                cmd="reactive__graph__client__help__entity__instances__list"
+                ;;
+            reactive__graph__client__help__entity__instances,list-components)
+                cmd="reactive__graph__client__help__entity__instances__list__components"
+                ;;
+            reactive__graph__client__help__entity__instances,list-properties)
+                cmd="reactive__graph__client__help__entity__instances__list__properties"
+                ;;
+            reactive__graph__client__help__entity__instances,remove-component)
+                cmd="reactive__graph__client__help__entity__instances__remove__component"
+                ;;
+            reactive__graph__client__help__entity__instances,remove-property)
+                cmd="reactive__graph__client__help__entity__instances__remove__property"
+                ;;
+            reactive__graph__client__help__entity__instances,set-property)
+                cmd="reactive__graph__client__help__entity__instances__set__property"
+                ;;
+            reactive__graph__client__help__entity__types,add-component)
+                cmd="reactive__graph__client__help__entity__types__add__component"
+                ;;
+            reactive__graph__client__help__entity__types,add-extension)
+                cmd="reactive__graph__client__help__entity__types__add__extension"
+                ;;
+            reactive__graph__client__help__entity__types,add-property)
+                cmd="reactive__graph__client__help__entity__types__add__property"
+                ;;
+            reactive__graph__client__help__entity__types,create)
+                cmd="reactive__graph__client__help__entity__types__create"
+                ;;
+            reactive__graph__client__help__entity__types,delete)
+                cmd="reactive__graph__client__help__entity__types__delete"
+                ;;
+            reactive__graph__client__help__entity__types,get)
+                cmd="reactive__graph__client__help__entity__types__get"
+                ;;
+            reactive__graph__client__help__entity__types,list)
+                cmd="reactive__graph__client__help__entity__types__list"
+                ;;
+            reactive__graph__client__help__entity__types,list-components)
+                cmd="reactive__graph__client__help__entity__types__list__components"
+                ;;
+            reactive__graph__client__help__entity__types,list-extensions)
+                cmd="reactive__graph__client__help__entity__types__list__extensions"
+                ;;
+            reactive__graph__client__help__entity__types,list-properties)
+                cmd="reactive__graph__client__help__entity__types__list__properties"
+                ;;
+            reactive__graph__client__help__entity__types,remove-component)
+                cmd="reactive__graph__client__help__entity__types__remove__component"
+                ;;
+            reactive__graph__client__help__entity__types,remove-extension)
+                cmd="reactive__graph__client__help__entity__types__remove__extension"
+                ;;
+            reactive__graph__client__help__entity__types,remove-property)
+                cmd="reactive__graph__client__help__entity__types__remove__property"
+                ;;
+            reactive__graph__client__help__entity__types,update-description)
+                cmd="reactive__graph__client__help__entity__types__update__description"
+                ;;
+            reactive__graph__client__help__instance__info,get)
+                cmd="reactive__graph__client__help__instance__info__get"
+                ;;
+            reactive__graph__client__help__plugins,dependencies)
+                cmd="reactive__graph__client__help__plugins__dependencies"
+                ;;
+            reactive__graph__client__help__plugins,dependents)
+                cmd="reactive__graph__client__help__plugins__dependents"
+                ;;
+            reactive__graph__client__help__plugins,get)
+                cmd="reactive__graph__client__help__plugins__get"
+                ;;
+            reactive__graph__client__help__plugins,list)
+                cmd="reactive__graph__client__help__plugins__list"
+                ;;
+            reactive__graph__client__help__plugins,restart)
+                cmd="reactive__graph__client__help__plugins__restart"
+                ;;
+            reactive__graph__client__help__plugins,search)
+                cmd="reactive__graph__client__help__plugins__search"
+                ;;
+            reactive__graph__client__help__plugins,start)
+                cmd="reactive__graph__client__help__plugins__start"
+                ;;
+            reactive__graph__client__help__plugins,stop)
+                cmd="reactive__graph__client__help__plugins__stop"
+                ;;
+            reactive__graph__client__help__plugins,uninstall)
+                cmd="reactive__graph__client__help__plugins__uninstall"
+                ;;
+            reactive__graph__client__help__relation__instances,add-component)
+                cmd="reactive__graph__client__help__relation__instances__add__component"
+                ;;
+            reactive__graph__client__help__relation__instances,add-property)
+                cmd="reactive__graph__client__help__relation__instances__add__property"
+                ;;
+            reactive__graph__client__help__relation__instances,create)
+                cmd="reactive__graph__client__help__relation__instances__create"
+                ;;
+            reactive__graph__client__help__relation__instances,delete)
+                cmd="reactive__graph__client__help__relation__instances__delete"
+                ;;
+            reactive__graph__client__help__relation__instances,get)
+                cmd="reactive__graph__client__help__relation__instances__get"
+                ;;
+            reactive__graph__client__help__relation__instances,get-property)
+                cmd="reactive__graph__client__help__relation__instances__get__property"
+                ;;
+            reactive__graph__client__help__relation__instances,list)
+                cmd="reactive__graph__client__help__relation__instances__list"
+                ;;
+            reactive__graph__client__help__relation__instances,list-components)
+                cmd="reactive__graph__client__help__relation__instances__list__components"
+                ;;
+            reactive__graph__client__help__relation__instances,list-properties)
+                cmd="reactive__graph__client__help__relation__instances__list__properties"
+                ;;
+            reactive__graph__client__help__relation__instances,remove-component)
+                cmd="reactive__graph__client__help__relation__instances__remove__component"
+                ;;
+            reactive__graph__client__help__relation__instances,remove-property)
+                cmd="reactive__graph__client__help__relation__instances__remove__property"
+                ;;
+            reactive__graph__client__help__relation__instances,set-property)
+                cmd="reactive__graph__client__help__relation__instances__set__property"
+                ;;
+            reactive__graph__client__help__relation__types,add-component)
+                cmd="reactive__graph__client__help__relation__types__add__component"
+                ;;
+            reactive__graph__client__help__relation__types,add-extension)
+                cmd="reactive__graph__client__help__relation__types__add__extension"
+                ;;
+            reactive__graph__client__help__relation__types,add-property)
+                cmd="reactive__graph__client__help__relation__types__add__property"
+                ;;
+            reactive__graph__client__help__relation__types,create)
+                cmd="reactive__graph__client__help__relation__types__create"
+                ;;
+            reactive__graph__client__help__relation__types,delete)
+                cmd="reactive__graph__client__help__relation__types__delete"
+                ;;
+            reactive__graph__client__help__relation__types,get)
+                cmd="reactive__graph__client__help__relation__types__get"
+                ;;
+            reactive__graph__client__help__relation__types,list)
+                cmd="reactive__graph__client__help__relation__types__list"
+                ;;
+            reactive__graph__client__help__relation__types,list-components)
+                cmd="reactive__graph__client__help__relation__types__list__components"
+                ;;
+            reactive__graph__client__help__relation__types,list-extensions)
+                cmd="reactive__graph__client__help__relation__types__list__extensions"
+                ;;
+            reactive__graph__client__help__relation__types,list-properties)
+                cmd="reactive__graph__client__help__relation__types__list__properties"
+                ;;
+            reactive__graph__client__help__relation__types,remove-component)
+                cmd="reactive__graph__client__help__relation__types__remove__component"
+                ;;
+            reactive__graph__client__help__relation__types,remove-extension)
+                cmd="reactive__graph__client__help__relation__types__remove__extension"
+                ;;
+            reactive__graph__client__help__relation__types,remove-property)
+                cmd="reactive__graph__client__help__relation__types__remove__property"
+                ;;
+            reactive__graph__client__help__relation__types,update-description)
+                cmd="reactive__graph__client__help__relation__types__update__description"
+                ;;
+            reactive__graph__client__help__remotes,add)
+                cmd="reactive__graph__client__help__remotes__add"
+                ;;
+            reactive__graph__client__help__remotes,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__client__help__remotes__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__client__help__remotes,fetch-remotes-from-remote)
+                cmd="reactive__graph__client__help__remotes__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__client__help__remotes,list)
+                cmd="reactive__graph__client__help__remotes__list"
+                ;;
+            reactive__graph__client__help__remotes,remove)
+                cmd="reactive__graph__client__help__remotes__remove"
+                ;;
+            reactive__graph__client__help__remotes,remove-all)
+                cmd="reactive__graph__client__help__remotes__remove__all"
+                ;;
+            reactive__graph__client__help__remotes,update)
+                cmd="reactive__graph__client__help__remotes__update"
+                ;;
+            reactive__graph__client__help__remotes,update-all)
+                cmd="reactive__graph__client__help__remotes__update__all"
+                ;;
+            reactive__graph__client__instance__info,get)
+                cmd="reactive__graph__client__instance__info__get"
+                ;;
+            reactive__graph__client__instance__info,help)
+                cmd="reactive__graph__client__instance__info__help"
+                ;;
+            reactive__graph__client__instance__info__help,get)
+                cmd="reactive__graph__client__instance__info__help__get"
+                ;;
+            reactive__graph__client__instance__info__help,help)
+                cmd="reactive__graph__client__instance__info__help__help"
+                ;;
+            reactive__graph__client__plugins,dependencies)
+                cmd="reactive__graph__client__plugins__dependencies"
+                ;;
+            reactive__graph__client__plugins,dependents)
+                cmd="reactive__graph__client__plugins__dependents"
+                ;;
+            reactive__graph__client__plugins,get)
+                cmd="reactive__graph__client__plugins__get"
+                ;;
+            reactive__graph__client__plugins,help)
+                cmd="reactive__graph__client__plugins__help"
+                ;;
+            reactive__graph__client__plugins,list)
+                cmd="reactive__graph__client__plugins__list"
+                ;;
+            reactive__graph__client__plugins,restart)
+                cmd="reactive__graph__client__plugins__restart"
+                ;;
+            reactive__graph__client__plugins,search)
+                cmd="reactive__graph__client__plugins__search"
+                ;;
+            reactive__graph__client__plugins,start)
+                cmd="reactive__graph__client__plugins__start"
+                ;;
+            reactive__graph__client__plugins,stop)
+                cmd="reactive__graph__client__plugins__stop"
+                ;;
+            reactive__graph__client__plugins,uninstall)
+                cmd="reactive__graph__client__plugins__uninstall"
+                ;;
+            reactive__graph__client__plugins__help,dependencies)
+                cmd="reactive__graph__client__plugins__help__dependencies"
+                ;;
+            reactive__graph__client__plugins__help,dependents)
+                cmd="reactive__graph__client__plugins__help__dependents"
+                ;;
+            reactive__graph__client__plugins__help,get)
+                cmd="reactive__graph__client__plugins__help__get"
+                ;;
+            reactive__graph__client__plugins__help,help)
+                cmd="reactive__graph__client__plugins__help__help"
+                ;;
+            reactive__graph__client__plugins__help,list)
+                cmd="reactive__graph__client__plugins__help__list"
+                ;;
+            reactive__graph__client__plugins__help,restart)
+                cmd="reactive__graph__client__plugins__help__restart"
+                ;;
+            reactive__graph__client__plugins__help,search)
+                cmd="reactive__graph__client__plugins__help__search"
+                ;;
+            reactive__graph__client__plugins__help,start)
+                cmd="reactive__graph__client__plugins__help__start"
+                ;;
+            reactive__graph__client__plugins__help,stop)
+                cmd="reactive__graph__client__plugins__help__stop"
+                ;;
+            reactive__graph__client__plugins__help,uninstall)
+                cmd="reactive__graph__client__plugins__help__uninstall"
+                ;;
+            reactive__graph__client__relation__instances,add-component)
+                cmd="reactive__graph__client__relation__instances__add__component"
+                ;;
+            reactive__graph__client__relation__instances,add-property)
+                cmd="reactive__graph__client__relation__instances__add__property"
+                ;;
+            reactive__graph__client__relation__instances,create)
+                cmd="reactive__graph__client__relation__instances__create"
+                ;;
+            reactive__graph__client__relation__instances,delete)
+                cmd="reactive__graph__client__relation__instances__delete"
+                ;;
+            reactive__graph__client__relation__instances,get)
+                cmd="reactive__graph__client__relation__instances__get"
+                ;;
+            reactive__graph__client__relation__instances,get-property)
+                cmd="reactive__graph__client__relation__instances__get__property"
+                ;;
+            reactive__graph__client__relation__instances,help)
+                cmd="reactive__graph__client__relation__instances__help"
+                ;;
+            reactive__graph__client__relation__instances,list)
+                cmd="reactive__graph__client__relation__instances__list"
+                ;;
+            reactive__graph__client__relation__instances,list-components)
+                cmd="reactive__graph__client__relation__instances__list__components"
+                ;;
+            reactive__graph__client__relation__instances,list-properties)
+                cmd="reactive__graph__client__relation__instances__list__properties"
+                ;;
+            reactive__graph__client__relation__instances,remove-component)
+                cmd="reactive__graph__client__relation__instances__remove__component"
+                ;;
+            reactive__graph__client__relation__instances,remove-property)
+                cmd="reactive__graph__client__relation__instances__remove__property"
+                ;;
+            reactive__graph__client__relation__instances,set-property)
+                cmd="reactive__graph__client__relation__instances__set__property"
+                ;;
+            reactive__graph__client__relation__instances__help,add-component)
+                cmd="reactive__graph__client__relation__instances__help__add__component"
+                ;;
+            reactive__graph__client__relation__instances__help,add-property)
+                cmd="reactive__graph__client__relation__instances__help__add__property"
+                ;;
+            reactive__graph__client__relation__instances__help,create)
+                cmd="reactive__graph__client__relation__instances__help__create"
+                ;;
+            reactive__graph__client__relation__instances__help,delete)
+                cmd="reactive__graph__client__relation__instances__help__delete"
+                ;;
+            reactive__graph__client__relation__instances__help,get)
+                cmd="reactive__graph__client__relation__instances__help__get"
+                ;;
+            reactive__graph__client__relation__instances__help,get-property)
+                cmd="reactive__graph__client__relation__instances__help__get__property"
+                ;;
+            reactive__graph__client__relation__instances__help,help)
+                cmd="reactive__graph__client__relation__instances__help__help"
+                ;;
+            reactive__graph__client__relation__instances__help,list)
+                cmd="reactive__graph__client__relation__instances__help__list"
+                ;;
+            reactive__graph__client__relation__instances__help,list-components)
+                cmd="reactive__graph__client__relation__instances__help__list__components"
+                ;;
+            reactive__graph__client__relation__instances__help,list-properties)
+                cmd="reactive__graph__client__relation__instances__help__list__properties"
+                ;;
+            reactive__graph__client__relation__instances__help,remove-component)
+                cmd="reactive__graph__client__relation__instances__help__remove__component"
+                ;;
+            reactive__graph__client__relation__instances__help,remove-property)
+                cmd="reactive__graph__client__relation__instances__help__remove__property"
+                ;;
+            reactive__graph__client__relation__instances__help,set-property)
+                cmd="reactive__graph__client__relation__instances__help__set__property"
+                ;;
+            reactive__graph__client__relation__types,add-component)
+                cmd="reactive__graph__client__relation__types__add__component"
+                ;;
+            reactive__graph__client__relation__types,add-extension)
+                cmd="reactive__graph__client__relation__types__add__extension"
+                ;;
+            reactive__graph__client__relation__types,add-property)
+                cmd="reactive__graph__client__relation__types__add__property"
+                ;;
+            reactive__graph__client__relation__types,create)
+                cmd="reactive__graph__client__relation__types__create"
+                ;;
+            reactive__graph__client__relation__types,delete)
+                cmd="reactive__graph__client__relation__types__delete"
+                ;;
+            reactive__graph__client__relation__types,get)
+                cmd="reactive__graph__client__relation__types__get"
+                ;;
+            reactive__graph__client__relation__types,help)
+                cmd="reactive__graph__client__relation__types__help"
+                ;;
+            reactive__graph__client__relation__types,list)
+                cmd="reactive__graph__client__relation__types__list"
+                ;;
+            reactive__graph__client__relation__types,list-components)
+                cmd="reactive__graph__client__relation__types__list__components"
+                ;;
+            reactive__graph__client__relation__types,list-extensions)
+                cmd="reactive__graph__client__relation__types__list__extensions"
+                ;;
+            reactive__graph__client__relation__types,list-properties)
+                cmd="reactive__graph__client__relation__types__list__properties"
+                ;;
+            reactive__graph__client__relation__types,remove-component)
+                cmd="reactive__graph__client__relation__types__remove__component"
+                ;;
+            reactive__graph__client__relation__types,remove-extension)
+                cmd="reactive__graph__client__relation__types__remove__extension"
+                ;;
+            reactive__graph__client__relation__types,remove-property)
+                cmd="reactive__graph__client__relation__types__remove__property"
+                ;;
+            reactive__graph__client__relation__types,update-description)
+                cmd="reactive__graph__client__relation__types__update__description"
+                ;;
+            reactive__graph__client__relation__types__help,add-component)
+                cmd="reactive__graph__client__relation__types__help__add__component"
+                ;;
+            reactive__graph__client__relation__types__help,add-extension)
+                cmd="reactive__graph__client__relation__types__help__add__extension"
+                ;;
+            reactive__graph__client__relation__types__help,add-property)
+                cmd="reactive__graph__client__relation__types__help__add__property"
+                ;;
+            reactive__graph__client__relation__types__help,create)
+                cmd="reactive__graph__client__relation__types__help__create"
+                ;;
+            reactive__graph__client__relation__types__help,delete)
+                cmd="reactive__graph__client__relation__types__help__delete"
+                ;;
+            reactive__graph__client__relation__types__help,get)
+                cmd="reactive__graph__client__relation__types__help__get"
+                ;;
+            reactive__graph__client__relation__types__help,help)
+                cmd="reactive__graph__client__relation__types__help__help"
+                ;;
+            reactive__graph__client__relation__types__help,list)
+                cmd="reactive__graph__client__relation__types__help__list"
+                ;;
+            reactive__graph__client__relation__types__help,list-components)
+                cmd="reactive__graph__client__relation__types__help__list__components"
+                ;;
+            reactive__graph__client__relation__types__help,list-extensions)
+                cmd="reactive__graph__client__relation__types__help__list__extensions"
+                ;;
+            reactive__graph__client__relation__types__help,list-properties)
+                cmd="reactive__graph__client__relation__types__help__list__properties"
+                ;;
+            reactive__graph__client__relation__types__help,remove-component)
+                cmd="reactive__graph__client__relation__types__help__remove__component"
+                ;;
+            reactive__graph__client__relation__types__help,remove-extension)
+                cmd="reactive__graph__client__relation__types__help__remove__extension"
+                ;;
+            reactive__graph__client__relation__types__help,remove-property)
+                cmd="reactive__graph__client__relation__types__help__remove__property"
+                ;;
+            reactive__graph__client__relation__types__help,update-description)
+                cmd="reactive__graph__client__relation__types__help__update__description"
+                ;;
+            reactive__graph__client__remotes,add)
+                cmd="reactive__graph__client__remotes__add"
+                ;;
+            reactive__graph__client__remotes,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__client__remotes__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__client__remotes,fetch-remotes-from-remote)
+                cmd="reactive__graph__client__remotes__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__client__remotes,help)
+                cmd="reactive__graph__client__remotes__help"
+                ;;
+            reactive__graph__client__remotes,list)
+                cmd="reactive__graph__client__remotes__list"
+                ;;
+            reactive__graph__client__remotes,remove)
+                cmd="reactive__graph__client__remotes__remove"
+                ;;
+            reactive__graph__client__remotes,remove-all)
+                cmd="reactive__graph__client__remotes__remove__all"
+                ;;
+            reactive__graph__client__remotes,update)
+                cmd="reactive__graph__client__remotes__update"
+                ;;
+            reactive__graph__client__remotes,update-all)
+                cmd="reactive__graph__client__remotes__update__all"
+                ;;
+            reactive__graph__client__remotes__help,add)
+                cmd="reactive__graph__client__remotes__help__add"
+                ;;
+            reactive__graph__client__remotes__help,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__client__remotes__help__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__client__remotes__help,fetch-remotes-from-remote)
+                cmd="reactive__graph__client__remotes__help__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__client__remotes__help,help)
+                cmd="reactive__graph__client__remotes__help__help"
+                ;;
+            reactive__graph__client__remotes__help,list)
+                cmd="reactive__graph__client__remotes__help__list"
+                ;;
+            reactive__graph__client__remotes__help,remove)
+                cmd="reactive__graph__client__remotes__help__remove"
+                ;;
+            reactive__graph__client__remotes__help,remove-all)
+                cmd="reactive__graph__client__remotes__help__remove__all"
+                ;;
+            reactive__graph__client__remotes__help,update)
+                cmd="reactive__graph__client__remotes__help__update"
+                ;;
+            reactive__graph__client__remotes__help,update-all)
+                cmd="reactive__graph__client__remotes__help__update__all"
+                ;;
+            reactive__graph__help,client)
+                cmd="reactive__graph__help__client"
+                ;;
+            reactive__graph__help,help)
+                cmd="reactive__graph__help__help"
+                ;;
+            reactive__graph__help__client,components)
+                cmd="reactive__graph__help__client__components"
+                ;;
+            reactive__graph__help__client,entity-instances)
+                cmd="reactive__graph__help__client__entity__instances"
+                ;;
+            reactive__graph__help__client,entity-types)
+                cmd="reactive__graph__help__client__entity__types"
+                ;;
+            reactive__graph__help__client,execute-command)
+                cmd="reactive__graph__help__client__execute__command"
+                ;;
+            reactive__graph__help__client,instance-info)
+                cmd="reactive__graph__help__client__instance__info"
+                ;;
+            reactive__graph__help__client,plugins)
+                cmd="reactive__graph__help__client__plugins"
+                ;;
+            reactive__graph__help__client,relation-instances)
+                cmd="reactive__graph__help__client__relation__instances"
+                ;;
+            reactive__graph__help__client,relation-types)
+                cmd="reactive__graph__help__client__relation__types"
+                ;;
+            reactive__graph__help__client,remotes)
+                cmd="reactive__graph__help__client__remotes"
+                ;;
+            reactive__graph__help__client,shutdown)
+                cmd="reactive__graph__help__client__shutdown"
+                ;;
+            reactive__graph__help__client__components,add-extension)
+                cmd="reactive__graph__help__client__components__add__extension"
+                ;;
+            reactive__graph__help__client__components,add-property)
+                cmd="reactive__graph__help__client__components__add__property"
+                ;;
+            reactive__graph__help__client__components,create)
+                cmd="reactive__graph__help__client__components__create"
+                ;;
+            reactive__graph__help__client__components,delete)
+                cmd="reactive__graph__help__client__components__delete"
+                ;;
+            reactive__graph__help__client__components,get)
+                cmd="reactive__graph__help__client__components__get"
+                ;;
+            reactive__graph__help__client__components,list)
+                cmd="reactive__graph__help__client__components__list"
+                ;;
+            reactive__graph__help__client__components,list-extensions)
+                cmd="reactive__graph__help__client__components__list__extensions"
+                ;;
+            reactive__graph__help__client__components,list-properties)
+                cmd="reactive__graph__help__client__components__list__properties"
+                ;;
+            reactive__graph__help__client__components,remove-extension)
+                cmd="reactive__graph__help__client__components__remove__extension"
+                ;;
+            reactive__graph__help__client__components,remove-property)
+                cmd="reactive__graph__help__client__components__remove__property"
+                ;;
+            reactive__graph__help__client__components,update-description)
+                cmd="reactive__graph__help__client__components__update__description"
+                ;;
+            reactive__graph__help__client__entity__instances,add-component)
+                cmd="reactive__graph__help__client__entity__instances__add__component"
+                ;;
+            reactive__graph__help__client__entity__instances,add-property)
+                cmd="reactive__graph__help__client__entity__instances__add__property"
+                ;;
+            reactive__graph__help__client__entity__instances,create)
+                cmd="reactive__graph__help__client__entity__instances__create"
+                ;;
+            reactive__graph__help__client__entity__instances,delete)
+                cmd="reactive__graph__help__client__entity__instances__delete"
+                ;;
+            reactive__graph__help__client__entity__instances,get)
+                cmd="reactive__graph__help__client__entity__instances__get"
+                ;;
+            reactive__graph__help__client__entity__instances,get-by-label)
+                cmd="reactive__graph__help__client__entity__instances__get__by__label"
+                ;;
+            reactive__graph__help__client__entity__instances,get-property)
+                cmd="reactive__graph__help__client__entity__instances__get__property"
+                ;;
+            reactive__graph__help__client__entity__instances,list)
+                cmd="reactive__graph__help__client__entity__instances__list"
+                ;;
+            reactive__graph__help__client__entity__instances,list-components)
+                cmd="reactive__graph__help__client__entity__instances__list__components"
+                ;;
+            reactive__graph__help__client__entity__instances,list-properties)
+                cmd="reactive__graph__help__client__entity__instances__list__properties"
+                ;;
+            reactive__graph__help__client__entity__instances,remove-component)
+                cmd="reactive__graph__help__client__entity__instances__remove__component"
+                ;;
+            reactive__graph__help__client__entity__instances,remove-property)
+                cmd="reactive__graph__help__client__entity__instances__remove__property"
+                ;;
+            reactive__graph__help__client__entity__instances,set-property)
+                cmd="reactive__graph__help__client__entity__instances__set__property"
+                ;;
+            reactive__graph__help__client__entity__types,add-component)
+                cmd="reactive__graph__help__client__entity__types__add__component"
+                ;;
+            reactive__graph__help__client__entity__types,add-extension)
+                cmd="reactive__graph__help__client__entity__types__add__extension"
+                ;;
+            reactive__graph__help__client__entity__types,add-property)
+                cmd="reactive__graph__help__client__entity__types__add__property"
+                ;;
+            reactive__graph__help__client__entity__types,create)
+                cmd="reactive__graph__help__client__entity__types__create"
+                ;;
+            reactive__graph__help__client__entity__types,delete)
+                cmd="reactive__graph__help__client__entity__types__delete"
+                ;;
+            reactive__graph__help__client__entity__types,get)
+                cmd="reactive__graph__help__client__entity__types__get"
+                ;;
+            reactive__graph__help__client__entity__types,list)
+                cmd="reactive__graph__help__client__entity__types__list"
+                ;;
+            reactive__graph__help__client__entity__types,list-components)
+                cmd="reactive__graph__help__client__entity__types__list__components"
+                ;;
+            reactive__graph__help__client__entity__types,list-extensions)
+                cmd="reactive__graph__help__client__entity__types__list__extensions"
+                ;;
+            reactive__graph__help__client__entity__types,list-properties)
+                cmd="reactive__graph__help__client__entity__types__list__properties"
+                ;;
+            reactive__graph__help__client__entity__types,remove-component)
+                cmd="reactive__graph__help__client__entity__types__remove__component"
+                ;;
+            reactive__graph__help__client__entity__types,remove-extension)
+                cmd="reactive__graph__help__client__entity__types__remove__extension"
+                ;;
+            reactive__graph__help__client__entity__types,remove-property)
+                cmd="reactive__graph__help__client__entity__types__remove__property"
+                ;;
+            reactive__graph__help__client__entity__types,update-description)
+                cmd="reactive__graph__help__client__entity__types__update__description"
+                ;;
+            reactive__graph__help__client__instance__info,get)
+                cmd="reactive__graph__help__client__instance__info__get"
+                ;;
+            reactive__graph__help__client__plugins,dependencies)
+                cmd="reactive__graph__help__client__plugins__dependencies"
+                ;;
+            reactive__graph__help__client__plugins,dependents)
+                cmd="reactive__graph__help__client__plugins__dependents"
+                ;;
+            reactive__graph__help__client__plugins,get)
+                cmd="reactive__graph__help__client__plugins__get"
+                ;;
+            reactive__graph__help__client__plugins,list)
+                cmd="reactive__graph__help__client__plugins__list"
+                ;;
+            reactive__graph__help__client__plugins,restart)
+                cmd="reactive__graph__help__client__plugins__restart"
+                ;;
+            reactive__graph__help__client__plugins,search)
+                cmd="reactive__graph__help__client__plugins__search"
+                ;;
+            reactive__graph__help__client__plugins,start)
+                cmd="reactive__graph__help__client__plugins__start"
+                ;;
+            reactive__graph__help__client__plugins,stop)
+                cmd="reactive__graph__help__client__plugins__stop"
+                ;;
+            reactive__graph__help__client__plugins,uninstall)
+                cmd="reactive__graph__help__client__plugins__uninstall"
+                ;;
+            reactive__graph__help__client__relation__instances,add-component)
+                cmd="reactive__graph__help__client__relation__instances__add__component"
+                ;;
+            reactive__graph__help__client__relation__instances,add-property)
+                cmd="reactive__graph__help__client__relation__instances__add__property"
+                ;;
+            reactive__graph__help__client__relation__instances,create)
+                cmd="reactive__graph__help__client__relation__instances__create"
+                ;;
+            reactive__graph__help__client__relation__instances,delete)
+                cmd="reactive__graph__help__client__relation__instances__delete"
+                ;;
+            reactive__graph__help__client__relation__instances,get)
+                cmd="reactive__graph__help__client__relation__instances__get"
+                ;;
+            reactive__graph__help__client__relation__instances,get-property)
+                cmd="reactive__graph__help__client__relation__instances__get__property"
+                ;;
+            reactive__graph__help__client__relation__instances,list)
+                cmd="reactive__graph__help__client__relation__instances__list"
+                ;;
+            reactive__graph__help__client__relation__instances,list-components)
+                cmd="reactive__graph__help__client__relation__instances__list__components"
+                ;;
+            reactive__graph__help__client__relation__instances,list-properties)
+                cmd="reactive__graph__help__client__relation__instances__list__properties"
+                ;;
+            reactive__graph__help__client__relation__instances,remove-component)
+                cmd="reactive__graph__help__client__relation__instances__remove__component"
+                ;;
+            reactive__graph__help__client__relation__instances,remove-property)
+                cmd="reactive__graph__help__client__relation__instances__remove__property"
+                ;;
+            reactive__graph__help__client__relation__instances,set-property)
+                cmd="reactive__graph__help__client__relation__instances__set__property"
+                ;;
+            reactive__graph__help__client__relation__types,add-component)
+                cmd="reactive__graph__help__client__relation__types__add__component"
+                ;;
+            reactive__graph__help__client__relation__types,add-extension)
+                cmd="reactive__graph__help__client__relation__types__add__extension"
+                ;;
+            reactive__graph__help__client__relation__types,add-property)
+                cmd="reactive__graph__help__client__relation__types__add__property"
+                ;;
+            reactive__graph__help__client__relation__types,create)
+                cmd="reactive__graph__help__client__relation__types__create"
+                ;;
+            reactive__graph__help__client__relation__types,delete)
+                cmd="reactive__graph__help__client__relation__types__delete"
+                ;;
+            reactive__graph__help__client__relation__types,get)
+                cmd="reactive__graph__help__client__relation__types__get"
+                ;;
+            reactive__graph__help__client__relation__types,list)
+                cmd="reactive__graph__help__client__relation__types__list"
+                ;;
+            reactive__graph__help__client__relation__types,list-components)
+                cmd="reactive__graph__help__client__relation__types__list__components"
+                ;;
+            reactive__graph__help__client__relation__types,list-extensions)
+                cmd="reactive__graph__help__client__relation__types__list__extensions"
+                ;;
+            reactive__graph__help__client__relation__types,list-properties)
+                cmd="reactive__graph__help__client__relation__types__list__properties"
+                ;;
+            reactive__graph__help__client__relation__types,remove-component)
+                cmd="reactive__graph__help__client__relation__types__remove__component"
+                ;;
+            reactive__graph__help__client__relation__types,remove-extension)
+                cmd="reactive__graph__help__client__relation__types__remove__extension"
+                ;;
+            reactive__graph__help__client__relation__types,remove-property)
+                cmd="reactive__graph__help__client__relation__types__remove__property"
+                ;;
+            reactive__graph__help__client__relation__types,update-description)
+                cmd="reactive__graph__help__client__relation__types__update__description"
+                ;;
+            reactive__graph__help__client__remotes,add)
+                cmd="reactive__graph__help__client__remotes__add"
+                ;;
+            reactive__graph__help__client__remotes,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__help__client__remotes__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__help__client__remotes,fetch-remotes-from-remote)
+                cmd="reactive__graph__help__client__remotes__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__help__client__remotes,list)
+                cmd="reactive__graph__help__client__remotes__list"
+                ;;
+            reactive__graph__help__client__remotes,remove)
+                cmd="reactive__graph__help__client__remotes__remove"
+                ;;
+            reactive__graph__help__client__remotes,remove-all)
+                cmd="reactive__graph__help__client__remotes__remove__all"
+                ;;
+            reactive__graph__help__client__remotes,update)
+                cmd="reactive__graph__help__client__remotes__update"
+                ;;
+            reactive__graph__help__client__remotes,update-all)
+                cmd="reactive__graph__help__client__remotes__update__all"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        reactive__graph)
+            opts="-n -d -w -c -x -p -P -q -D -h -V --logging-config --instance-config --graphql-config --plugins-config --instance-name --instance-description --hostname --port --secure --ssl-certificate-path --ssl-private-key-path --shutdown-timeout --workers --default-context-path --disable-all-plugins --disabled-plugins --enabled-plugins --disable-hot-deploy --hot-deploy-location --install-location --stop-immediately --quiet --markdown-help --print-shell-completions --install-shell-completions --daemon --daemon-name --daemon-pid --daemon-working-directory --daemon-stdout --daemon-stderr --daemon-user --daemon-group --help --version client help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --logging-config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --instance-config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --graphql-config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --plugins-config)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --instance-name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --instance-description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --ssl-certificate-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --ssl-private-key-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --shutdown-timeout)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --workers)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -w)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --default-context-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --disable-all-plugins)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                -x)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --disabled-plugins)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --enabled-plugins)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -P)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --disable-hot-deploy)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --hot-deploy-location)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --install-location)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --stop-immediately)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --quiet)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                -q)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --print-shell-completions)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --install-shell-completions)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --daemon-name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --daemon-pid)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --daemon-working-directory)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --daemon-stdout)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --daemon-stderr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --daemon-user)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --daemon-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client)
+            opts="-h -V --hostname --port --secure --endpoint-graphql --endpoint-dynamic-graph --endpoint-runtime --endpoint-plugins --bearer --markdown-help --print-shell-completions --install-shell-completions --help --version execute-command instance-info plugins remotes shutdown components entity-types relation-types entity-instances relation-instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-graphql)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-dynamic-graph)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-runtime)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-plugins)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --bearer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --print-shell-completions)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --install-shell-completions)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components)
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__add__extension)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME> <DESCRIPTION> <EXTENSION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__add__property)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__create)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__delete)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__get)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help)
+            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__list)
+            opts="-o -h -V --output-format --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__list__extensions)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__list__properties)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__remove__extension)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__remove__property)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__update__description)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <DESCRIPTION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances)
+            opts="-o -h -V --output-format --help --version list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__add__component)
+            opts="-o -h -V --output-format --help --version <ID> <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__add__property)
+            opts="-o -h -V --output-format --help --version <ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__create)
+            opts="-i -d -p -o -h -V --id --description --properties --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__delete)
+            opts="-o -h -V --output-format --help --version <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__get)
+            opts="-o -h -V --output-format --help --version <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__get__by__label)
+            opts="-o -h -V --output-format --help --version <LABEL>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__get__property)
+            opts="-o -h -V --output-format --help --version <ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help)
+            opts="list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__get__by__label)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__list)
+            opts="-n -i -l -p -c -o -h -V --namespace --name --id --label --properties --components --output-format --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --namespace)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --components)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__list__components)
+            opts="-o -h -V --output-format --help --version <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__list__properties)
+            opts="-o -h -V --output-format --help --version <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__remove__component)
+            opts="-o -h -V --output-format --help --version <ID> <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__remove__property)
+            opts="-o -h -V --output-format --help --version <ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__set__property)
+            opts="-o -h -V --output-format --help --version <ID> <NAME> <VALUE>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types)
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__add__component)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__add__extension)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME> <DESCRIPTION> <EXTENSION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__add__property)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__create)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__delete)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__get)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list)
+            opts="-o -h -V --output-format --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list__components)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list__extensions)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list__properties)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__remove__component)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__remove__extension)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__remove__property)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__update__description)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <DESCRIPTION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__execute__command)
+            opts="-h -V --help --version <COMMAND_NAME> [COMMAND_ARGUMENTS]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help)
+            opts="execute-command instance-info plugins remotes shutdown components entity-types relation-types entity-instances relation-instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components)
+            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances)
+            opts="list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__get__by__label)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__execute__command)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__instance__info)
+            opts="get"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__instance__info__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins)
+            opts="list search get dependencies dependents start stop restart uninstall"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__dependencies)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__dependents)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__restart)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__search)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__start)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__stop)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__uninstall)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances)
+            opts="list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes)
+            opts="list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__fetch__remotes__from__all__remotes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__fetch__remotes__from__remote)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__remove__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__update)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__update__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__shutdown)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info)
+            opts="-h -V --help --version get help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__get)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__help)
+            opts="get help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins)
+            opts="-h -V --help --version list search get dependencies dependents start stop restart uninstall help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__dependencies)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__dependents)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__get)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help)
+            opts="list search get dependencies dependents start stop restart uninstall help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__dependencies)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__dependents)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__restart)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__search)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__start)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__stop)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__uninstall)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__list)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__restart)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__search)
+            opts="-h -V --name --state --stem --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --state)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --stem)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__start)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__stop)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__uninstall)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances)
+            opts="-o -h -V --output-format --help --version list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__add__component)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__add__property)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__create)
+            opts="-i -d -p -o -h -V --outbound-id --inbound-id --description --properties --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__delete)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__get)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__get__property)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help)
+            opts="list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__list)
+            opts="-n -i -p -c -o -h -V --outbound-id --namespace --name --inbound-id --properties --components --output-format --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --namespace)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --components)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__list__components)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__list__properties)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__remove__component)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__remove__property)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__set__property)
+            opts="-i -o -h -V --outbound-id --inbound-id --output-format --help --version <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <PROPERTY_VALUE>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types)
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__add__component)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__add__extension)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME> <DESCRIPTION> <EXTENSION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__add__property)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__create)
+            opts="-o -h -V --output-format --help --version <OUTBOUND_TYPE_NAMESPACE> <OUTBOUND_TYPE_NAME> <NAMESPACE> <NAME> <INBOUND_TYPE_NAMESPACE> <INBOUND_TYPE_NAME> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__delete)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__get)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list)
+            opts="-o -h -V --output-format --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list__components)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list__extensions)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list__properties)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__remove__component)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__remove__extension)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__remove__property)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__update__description)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME> <DESCRIPTION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes)
+            opts="-h -V --help --version list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__add)
+            opts="-h -V --hostname --port --secure --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__fetch__remotes__from__all__remotes)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__fetch__remotes__from__remote)
+            opts="-h -V --hostname --port --secure --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help)
+            opts="list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__fetch__remotes__from__all__remotes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__fetch__remotes__from__remote)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__remove__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__update)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__update__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__list)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__remove)
+            opts="-h -V --hostname --port --secure --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__remove__all)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__update)
+            opts="-h -V --hostname --port --secure --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__update__all)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__shutdown)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help)
+            opts="client help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client)
+            opts="execute-command instance-info plugins remotes shutdown components entity-types relation-types entity-instances relation-instances"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components)
+            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__components__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances)
+            opts="list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__get__by__label)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__instances__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__entity__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__execute__command)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__instance__info)
+            opts="get"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__instance__info__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins)
+            opts="list search get dependencies dependents start stop restart uninstall"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__dependencies)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__dependents)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__restart)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__search)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__start)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__stop)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__plugins__uninstall)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances)
+            opts="list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__instances__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__relation__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes)
+            opts="list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__fetch__remotes__from__all__remotes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__fetch__remotes__from__remote)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__remove__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__update)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__remotes__update__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__client__shutdown)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _reactive-graph -o nosort -o bashdefault -o default reactive-graph
+else
+    complete -F _reactive-graph -o bashdefault -o default reactive-graph
+fi

--- a/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph-client
+++ b/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph-client
@@ -1,0 +1,5778 @@
+_reactive-graph-client() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd=""
+    opts=""
+
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="reactive__graph__client"
+                ;;
+            reactive__graph__client,components)
+                cmd="reactive__graph__client__components"
+                ;;
+            reactive__graph__client,entity-instances)
+                cmd="reactive__graph__client__entity__instances"
+                ;;
+            reactive__graph__client,entity-types)
+                cmd="reactive__graph__client__entity__types"
+                ;;
+            reactive__graph__client,execute-command)
+                cmd="reactive__graph__client__execute__command"
+                ;;
+            reactive__graph__client,help)
+                cmd="reactive__graph__client__help"
+                ;;
+            reactive__graph__client,instance-info)
+                cmd="reactive__graph__client__instance__info"
+                ;;
+            reactive__graph__client,plugins)
+                cmd="reactive__graph__client__plugins"
+                ;;
+            reactive__graph__client,relation-instances)
+                cmd="reactive__graph__client__relation__instances"
+                ;;
+            reactive__graph__client,relation-types)
+                cmd="reactive__graph__client__relation__types"
+                ;;
+            reactive__graph__client,remotes)
+                cmd="reactive__graph__client__remotes"
+                ;;
+            reactive__graph__client,shutdown)
+                cmd="reactive__graph__client__shutdown"
+                ;;
+            reactive__graph__client__components,add-extension)
+                cmd="reactive__graph__client__components__add__extension"
+                ;;
+            reactive__graph__client__components,add-property)
+                cmd="reactive__graph__client__components__add__property"
+                ;;
+            reactive__graph__client__components,create)
+                cmd="reactive__graph__client__components__create"
+                ;;
+            reactive__graph__client__components,delete)
+                cmd="reactive__graph__client__components__delete"
+                ;;
+            reactive__graph__client__components,get)
+                cmd="reactive__graph__client__components__get"
+                ;;
+            reactive__graph__client__components,help)
+                cmd="reactive__graph__client__components__help"
+                ;;
+            reactive__graph__client__components,list)
+                cmd="reactive__graph__client__components__list"
+                ;;
+            reactive__graph__client__components,list-extensions)
+                cmd="reactive__graph__client__components__list__extensions"
+                ;;
+            reactive__graph__client__components,list-properties)
+                cmd="reactive__graph__client__components__list__properties"
+                ;;
+            reactive__graph__client__components,remove-extension)
+                cmd="reactive__graph__client__components__remove__extension"
+                ;;
+            reactive__graph__client__components,remove-property)
+                cmd="reactive__graph__client__components__remove__property"
+                ;;
+            reactive__graph__client__components,update-description)
+                cmd="reactive__graph__client__components__update__description"
+                ;;
+            reactive__graph__client__components__help,add-extension)
+                cmd="reactive__graph__client__components__help__add__extension"
+                ;;
+            reactive__graph__client__components__help,add-property)
+                cmd="reactive__graph__client__components__help__add__property"
+                ;;
+            reactive__graph__client__components__help,create)
+                cmd="reactive__graph__client__components__help__create"
+                ;;
+            reactive__graph__client__components__help,delete)
+                cmd="reactive__graph__client__components__help__delete"
+                ;;
+            reactive__graph__client__components__help,get)
+                cmd="reactive__graph__client__components__help__get"
+                ;;
+            reactive__graph__client__components__help,help)
+                cmd="reactive__graph__client__components__help__help"
+                ;;
+            reactive__graph__client__components__help,list)
+                cmd="reactive__graph__client__components__help__list"
+                ;;
+            reactive__graph__client__components__help,list-extensions)
+                cmd="reactive__graph__client__components__help__list__extensions"
+                ;;
+            reactive__graph__client__components__help,list-properties)
+                cmd="reactive__graph__client__components__help__list__properties"
+                ;;
+            reactive__graph__client__components__help,remove-extension)
+                cmd="reactive__graph__client__components__help__remove__extension"
+                ;;
+            reactive__graph__client__components__help,remove-property)
+                cmd="reactive__graph__client__components__help__remove__property"
+                ;;
+            reactive__graph__client__components__help,update-description)
+                cmd="reactive__graph__client__components__help__update__description"
+                ;;
+            reactive__graph__client__entity__instances,add-component)
+                cmd="reactive__graph__client__entity__instances__add__component"
+                ;;
+            reactive__graph__client__entity__instances,add-property)
+                cmd="reactive__graph__client__entity__instances__add__property"
+                ;;
+            reactive__graph__client__entity__instances,create)
+                cmd="reactive__graph__client__entity__instances__create"
+                ;;
+            reactive__graph__client__entity__instances,delete)
+                cmd="reactive__graph__client__entity__instances__delete"
+                ;;
+            reactive__graph__client__entity__instances,get)
+                cmd="reactive__graph__client__entity__instances__get"
+                ;;
+            reactive__graph__client__entity__instances,get-by-label)
+                cmd="reactive__graph__client__entity__instances__get__by__label"
+                ;;
+            reactive__graph__client__entity__instances,get-property)
+                cmd="reactive__graph__client__entity__instances__get__property"
+                ;;
+            reactive__graph__client__entity__instances,help)
+                cmd="reactive__graph__client__entity__instances__help"
+                ;;
+            reactive__graph__client__entity__instances,list)
+                cmd="reactive__graph__client__entity__instances__list"
+                ;;
+            reactive__graph__client__entity__instances,list-components)
+                cmd="reactive__graph__client__entity__instances__list__components"
+                ;;
+            reactive__graph__client__entity__instances,list-properties)
+                cmd="reactive__graph__client__entity__instances__list__properties"
+                ;;
+            reactive__graph__client__entity__instances,remove-component)
+                cmd="reactive__graph__client__entity__instances__remove__component"
+                ;;
+            reactive__graph__client__entity__instances,remove-property)
+                cmd="reactive__graph__client__entity__instances__remove__property"
+                ;;
+            reactive__graph__client__entity__instances,set-property)
+                cmd="reactive__graph__client__entity__instances__set__property"
+                ;;
+            reactive__graph__client__entity__instances__help,add-component)
+                cmd="reactive__graph__client__entity__instances__help__add__component"
+                ;;
+            reactive__graph__client__entity__instances__help,add-property)
+                cmd="reactive__graph__client__entity__instances__help__add__property"
+                ;;
+            reactive__graph__client__entity__instances__help,create)
+                cmd="reactive__graph__client__entity__instances__help__create"
+                ;;
+            reactive__graph__client__entity__instances__help,delete)
+                cmd="reactive__graph__client__entity__instances__help__delete"
+                ;;
+            reactive__graph__client__entity__instances__help,get)
+                cmd="reactive__graph__client__entity__instances__help__get"
+                ;;
+            reactive__graph__client__entity__instances__help,get-by-label)
+                cmd="reactive__graph__client__entity__instances__help__get__by__label"
+                ;;
+            reactive__graph__client__entity__instances__help,get-property)
+                cmd="reactive__graph__client__entity__instances__help__get__property"
+                ;;
+            reactive__graph__client__entity__instances__help,help)
+                cmd="reactive__graph__client__entity__instances__help__help"
+                ;;
+            reactive__graph__client__entity__instances__help,list)
+                cmd="reactive__graph__client__entity__instances__help__list"
+                ;;
+            reactive__graph__client__entity__instances__help,list-components)
+                cmd="reactive__graph__client__entity__instances__help__list__components"
+                ;;
+            reactive__graph__client__entity__instances__help,list-properties)
+                cmd="reactive__graph__client__entity__instances__help__list__properties"
+                ;;
+            reactive__graph__client__entity__instances__help,remove-component)
+                cmd="reactive__graph__client__entity__instances__help__remove__component"
+                ;;
+            reactive__graph__client__entity__instances__help,remove-property)
+                cmd="reactive__graph__client__entity__instances__help__remove__property"
+                ;;
+            reactive__graph__client__entity__instances__help,set-property)
+                cmd="reactive__graph__client__entity__instances__help__set__property"
+                ;;
+            reactive__graph__client__entity__types,add-component)
+                cmd="reactive__graph__client__entity__types__add__component"
+                ;;
+            reactive__graph__client__entity__types,add-extension)
+                cmd="reactive__graph__client__entity__types__add__extension"
+                ;;
+            reactive__graph__client__entity__types,add-property)
+                cmd="reactive__graph__client__entity__types__add__property"
+                ;;
+            reactive__graph__client__entity__types,create)
+                cmd="reactive__graph__client__entity__types__create"
+                ;;
+            reactive__graph__client__entity__types,delete)
+                cmd="reactive__graph__client__entity__types__delete"
+                ;;
+            reactive__graph__client__entity__types,get)
+                cmd="reactive__graph__client__entity__types__get"
+                ;;
+            reactive__graph__client__entity__types,help)
+                cmd="reactive__graph__client__entity__types__help"
+                ;;
+            reactive__graph__client__entity__types,list)
+                cmd="reactive__graph__client__entity__types__list"
+                ;;
+            reactive__graph__client__entity__types,list-components)
+                cmd="reactive__graph__client__entity__types__list__components"
+                ;;
+            reactive__graph__client__entity__types,list-extensions)
+                cmd="reactive__graph__client__entity__types__list__extensions"
+                ;;
+            reactive__graph__client__entity__types,list-properties)
+                cmd="reactive__graph__client__entity__types__list__properties"
+                ;;
+            reactive__graph__client__entity__types,remove-component)
+                cmd="reactive__graph__client__entity__types__remove__component"
+                ;;
+            reactive__graph__client__entity__types,remove-extension)
+                cmd="reactive__graph__client__entity__types__remove__extension"
+                ;;
+            reactive__graph__client__entity__types,remove-property)
+                cmd="reactive__graph__client__entity__types__remove__property"
+                ;;
+            reactive__graph__client__entity__types,update-description)
+                cmd="reactive__graph__client__entity__types__update__description"
+                ;;
+            reactive__graph__client__entity__types__help,add-component)
+                cmd="reactive__graph__client__entity__types__help__add__component"
+                ;;
+            reactive__graph__client__entity__types__help,add-extension)
+                cmd="reactive__graph__client__entity__types__help__add__extension"
+                ;;
+            reactive__graph__client__entity__types__help,add-property)
+                cmd="reactive__graph__client__entity__types__help__add__property"
+                ;;
+            reactive__graph__client__entity__types__help,create)
+                cmd="reactive__graph__client__entity__types__help__create"
+                ;;
+            reactive__graph__client__entity__types__help,delete)
+                cmd="reactive__graph__client__entity__types__help__delete"
+                ;;
+            reactive__graph__client__entity__types__help,get)
+                cmd="reactive__graph__client__entity__types__help__get"
+                ;;
+            reactive__graph__client__entity__types__help,help)
+                cmd="reactive__graph__client__entity__types__help__help"
+                ;;
+            reactive__graph__client__entity__types__help,list)
+                cmd="reactive__graph__client__entity__types__help__list"
+                ;;
+            reactive__graph__client__entity__types__help,list-components)
+                cmd="reactive__graph__client__entity__types__help__list__components"
+                ;;
+            reactive__graph__client__entity__types__help,list-extensions)
+                cmd="reactive__graph__client__entity__types__help__list__extensions"
+                ;;
+            reactive__graph__client__entity__types__help,list-properties)
+                cmd="reactive__graph__client__entity__types__help__list__properties"
+                ;;
+            reactive__graph__client__entity__types__help,remove-component)
+                cmd="reactive__graph__client__entity__types__help__remove__component"
+                ;;
+            reactive__graph__client__entity__types__help,remove-extension)
+                cmd="reactive__graph__client__entity__types__help__remove__extension"
+                ;;
+            reactive__graph__client__entity__types__help,remove-property)
+                cmd="reactive__graph__client__entity__types__help__remove__property"
+                ;;
+            reactive__graph__client__entity__types__help,update-description)
+                cmd="reactive__graph__client__entity__types__help__update__description"
+                ;;
+            reactive__graph__client__help,components)
+                cmd="reactive__graph__client__help__components"
+                ;;
+            reactive__graph__client__help,entity-instances)
+                cmd="reactive__graph__client__help__entity__instances"
+                ;;
+            reactive__graph__client__help,entity-types)
+                cmd="reactive__graph__client__help__entity__types"
+                ;;
+            reactive__graph__client__help,execute-command)
+                cmd="reactive__graph__client__help__execute__command"
+                ;;
+            reactive__graph__client__help,help)
+                cmd="reactive__graph__client__help__help"
+                ;;
+            reactive__graph__client__help,instance-info)
+                cmd="reactive__graph__client__help__instance__info"
+                ;;
+            reactive__graph__client__help,plugins)
+                cmd="reactive__graph__client__help__plugins"
+                ;;
+            reactive__graph__client__help,relation-instances)
+                cmd="reactive__graph__client__help__relation__instances"
+                ;;
+            reactive__graph__client__help,relation-types)
+                cmd="reactive__graph__client__help__relation__types"
+                ;;
+            reactive__graph__client__help,remotes)
+                cmd="reactive__graph__client__help__remotes"
+                ;;
+            reactive__graph__client__help,shutdown)
+                cmd="reactive__graph__client__help__shutdown"
+                ;;
+            reactive__graph__client__help__components,add-extension)
+                cmd="reactive__graph__client__help__components__add__extension"
+                ;;
+            reactive__graph__client__help__components,add-property)
+                cmd="reactive__graph__client__help__components__add__property"
+                ;;
+            reactive__graph__client__help__components,create)
+                cmd="reactive__graph__client__help__components__create"
+                ;;
+            reactive__graph__client__help__components,delete)
+                cmd="reactive__graph__client__help__components__delete"
+                ;;
+            reactive__graph__client__help__components,get)
+                cmd="reactive__graph__client__help__components__get"
+                ;;
+            reactive__graph__client__help__components,list)
+                cmd="reactive__graph__client__help__components__list"
+                ;;
+            reactive__graph__client__help__components,list-extensions)
+                cmd="reactive__graph__client__help__components__list__extensions"
+                ;;
+            reactive__graph__client__help__components,list-properties)
+                cmd="reactive__graph__client__help__components__list__properties"
+                ;;
+            reactive__graph__client__help__components,remove-extension)
+                cmd="reactive__graph__client__help__components__remove__extension"
+                ;;
+            reactive__graph__client__help__components,remove-property)
+                cmd="reactive__graph__client__help__components__remove__property"
+                ;;
+            reactive__graph__client__help__components,update-description)
+                cmd="reactive__graph__client__help__components__update__description"
+                ;;
+            reactive__graph__client__help__entity__instances,add-component)
+                cmd="reactive__graph__client__help__entity__instances__add__component"
+                ;;
+            reactive__graph__client__help__entity__instances,add-property)
+                cmd="reactive__graph__client__help__entity__instances__add__property"
+                ;;
+            reactive__graph__client__help__entity__instances,create)
+                cmd="reactive__graph__client__help__entity__instances__create"
+                ;;
+            reactive__graph__client__help__entity__instances,delete)
+                cmd="reactive__graph__client__help__entity__instances__delete"
+                ;;
+            reactive__graph__client__help__entity__instances,get)
+                cmd="reactive__graph__client__help__entity__instances__get"
+                ;;
+            reactive__graph__client__help__entity__instances,get-by-label)
+                cmd="reactive__graph__client__help__entity__instances__get__by__label"
+                ;;
+            reactive__graph__client__help__entity__instances,get-property)
+                cmd="reactive__graph__client__help__entity__instances__get__property"
+                ;;
+            reactive__graph__client__help__entity__instances,list)
+                cmd="reactive__graph__client__help__entity__instances__list"
+                ;;
+            reactive__graph__client__help__entity__instances,list-components)
+                cmd="reactive__graph__client__help__entity__instances__list__components"
+                ;;
+            reactive__graph__client__help__entity__instances,list-properties)
+                cmd="reactive__graph__client__help__entity__instances__list__properties"
+                ;;
+            reactive__graph__client__help__entity__instances,remove-component)
+                cmd="reactive__graph__client__help__entity__instances__remove__component"
+                ;;
+            reactive__graph__client__help__entity__instances,remove-property)
+                cmd="reactive__graph__client__help__entity__instances__remove__property"
+                ;;
+            reactive__graph__client__help__entity__instances,set-property)
+                cmd="reactive__graph__client__help__entity__instances__set__property"
+                ;;
+            reactive__graph__client__help__entity__types,add-component)
+                cmd="reactive__graph__client__help__entity__types__add__component"
+                ;;
+            reactive__graph__client__help__entity__types,add-extension)
+                cmd="reactive__graph__client__help__entity__types__add__extension"
+                ;;
+            reactive__graph__client__help__entity__types,add-property)
+                cmd="reactive__graph__client__help__entity__types__add__property"
+                ;;
+            reactive__graph__client__help__entity__types,create)
+                cmd="reactive__graph__client__help__entity__types__create"
+                ;;
+            reactive__graph__client__help__entity__types,delete)
+                cmd="reactive__graph__client__help__entity__types__delete"
+                ;;
+            reactive__graph__client__help__entity__types,get)
+                cmd="reactive__graph__client__help__entity__types__get"
+                ;;
+            reactive__graph__client__help__entity__types,list)
+                cmd="reactive__graph__client__help__entity__types__list"
+                ;;
+            reactive__graph__client__help__entity__types,list-components)
+                cmd="reactive__graph__client__help__entity__types__list__components"
+                ;;
+            reactive__graph__client__help__entity__types,list-extensions)
+                cmd="reactive__graph__client__help__entity__types__list__extensions"
+                ;;
+            reactive__graph__client__help__entity__types,list-properties)
+                cmd="reactive__graph__client__help__entity__types__list__properties"
+                ;;
+            reactive__graph__client__help__entity__types,remove-component)
+                cmd="reactive__graph__client__help__entity__types__remove__component"
+                ;;
+            reactive__graph__client__help__entity__types,remove-extension)
+                cmd="reactive__graph__client__help__entity__types__remove__extension"
+                ;;
+            reactive__graph__client__help__entity__types,remove-property)
+                cmd="reactive__graph__client__help__entity__types__remove__property"
+                ;;
+            reactive__graph__client__help__entity__types,update-description)
+                cmd="reactive__graph__client__help__entity__types__update__description"
+                ;;
+            reactive__graph__client__help__instance__info,get)
+                cmd="reactive__graph__client__help__instance__info__get"
+                ;;
+            reactive__graph__client__help__plugins,dependencies)
+                cmd="reactive__graph__client__help__plugins__dependencies"
+                ;;
+            reactive__graph__client__help__plugins,dependents)
+                cmd="reactive__graph__client__help__plugins__dependents"
+                ;;
+            reactive__graph__client__help__plugins,get)
+                cmd="reactive__graph__client__help__plugins__get"
+                ;;
+            reactive__graph__client__help__plugins,list)
+                cmd="reactive__graph__client__help__plugins__list"
+                ;;
+            reactive__graph__client__help__plugins,restart)
+                cmd="reactive__graph__client__help__plugins__restart"
+                ;;
+            reactive__graph__client__help__plugins,search)
+                cmd="reactive__graph__client__help__plugins__search"
+                ;;
+            reactive__graph__client__help__plugins,start)
+                cmd="reactive__graph__client__help__plugins__start"
+                ;;
+            reactive__graph__client__help__plugins,stop)
+                cmd="reactive__graph__client__help__plugins__stop"
+                ;;
+            reactive__graph__client__help__plugins,uninstall)
+                cmd="reactive__graph__client__help__plugins__uninstall"
+                ;;
+            reactive__graph__client__help__relation__instances,add-component)
+                cmd="reactive__graph__client__help__relation__instances__add__component"
+                ;;
+            reactive__graph__client__help__relation__instances,add-property)
+                cmd="reactive__graph__client__help__relation__instances__add__property"
+                ;;
+            reactive__graph__client__help__relation__instances,create)
+                cmd="reactive__graph__client__help__relation__instances__create"
+                ;;
+            reactive__graph__client__help__relation__instances,delete)
+                cmd="reactive__graph__client__help__relation__instances__delete"
+                ;;
+            reactive__graph__client__help__relation__instances,get)
+                cmd="reactive__graph__client__help__relation__instances__get"
+                ;;
+            reactive__graph__client__help__relation__instances,get-property)
+                cmd="reactive__graph__client__help__relation__instances__get__property"
+                ;;
+            reactive__graph__client__help__relation__instances,list)
+                cmd="reactive__graph__client__help__relation__instances__list"
+                ;;
+            reactive__graph__client__help__relation__instances,list-components)
+                cmd="reactive__graph__client__help__relation__instances__list__components"
+                ;;
+            reactive__graph__client__help__relation__instances,list-properties)
+                cmd="reactive__graph__client__help__relation__instances__list__properties"
+                ;;
+            reactive__graph__client__help__relation__instances,remove-component)
+                cmd="reactive__graph__client__help__relation__instances__remove__component"
+                ;;
+            reactive__graph__client__help__relation__instances,remove-property)
+                cmd="reactive__graph__client__help__relation__instances__remove__property"
+                ;;
+            reactive__graph__client__help__relation__instances,set-property)
+                cmd="reactive__graph__client__help__relation__instances__set__property"
+                ;;
+            reactive__graph__client__help__relation__types,add-component)
+                cmd="reactive__graph__client__help__relation__types__add__component"
+                ;;
+            reactive__graph__client__help__relation__types,add-extension)
+                cmd="reactive__graph__client__help__relation__types__add__extension"
+                ;;
+            reactive__graph__client__help__relation__types,add-property)
+                cmd="reactive__graph__client__help__relation__types__add__property"
+                ;;
+            reactive__graph__client__help__relation__types,create)
+                cmd="reactive__graph__client__help__relation__types__create"
+                ;;
+            reactive__graph__client__help__relation__types,delete)
+                cmd="reactive__graph__client__help__relation__types__delete"
+                ;;
+            reactive__graph__client__help__relation__types,get)
+                cmd="reactive__graph__client__help__relation__types__get"
+                ;;
+            reactive__graph__client__help__relation__types,list)
+                cmd="reactive__graph__client__help__relation__types__list"
+                ;;
+            reactive__graph__client__help__relation__types,list-components)
+                cmd="reactive__graph__client__help__relation__types__list__components"
+                ;;
+            reactive__graph__client__help__relation__types,list-extensions)
+                cmd="reactive__graph__client__help__relation__types__list__extensions"
+                ;;
+            reactive__graph__client__help__relation__types,list-properties)
+                cmd="reactive__graph__client__help__relation__types__list__properties"
+                ;;
+            reactive__graph__client__help__relation__types,remove-component)
+                cmd="reactive__graph__client__help__relation__types__remove__component"
+                ;;
+            reactive__graph__client__help__relation__types,remove-extension)
+                cmd="reactive__graph__client__help__relation__types__remove__extension"
+                ;;
+            reactive__graph__client__help__relation__types,remove-property)
+                cmd="reactive__graph__client__help__relation__types__remove__property"
+                ;;
+            reactive__graph__client__help__relation__types,update-description)
+                cmd="reactive__graph__client__help__relation__types__update__description"
+                ;;
+            reactive__graph__client__help__remotes,add)
+                cmd="reactive__graph__client__help__remotes__add"
+                ;;
+            reactive__graph__client__help__remotes,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__client__help__remotes__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__client__help__remotes,fetch-remotes-from-remote)
+                cmd="reactive__graph__client__help__remotes__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__client__help__remotes,list)
+                cmd="reactive__graph__client__help__remotes__list"
+                ;;
+            reactive__graph__client__help__remotes,remove)
+                cmd="reactive__graph__client__help__remotes__remove"
+                ;;
+            reactive__graph__client__help__remotes,remove-all)
+                cmd="reactive__graph__client__help__remotes__remove__all"
+                ;;
+            reactive__graph__client__help__remotes,update)
+                cmd="reactive__graph__client__help__remotes__update"
+                ;;
+            reactive__graph__client__help__remotes,update-all)
+                cmd="reactive__graph__client__help__remotes__update__all"
+                ;;
+            reactive__graph__client__instance__info,get)
+                cmd="reactive__graph__client__instance__info__get"
+                ;;
+            reactive__graph__client__instance__info,help)
+                cmd="reactive__graph__client__instance__info__help"
+                ;;
+            reactive__graph__client__instance__info__help,get)
+                cmd="reactive__graph__client__instance__info__help__get"
+                ;;
+            reactive__graph__client__instance__info__help,help)
+                cmd="reactive__graph__client__instance__info__help__help"
+                ;;
+            reactive__graph__client__plugins,dependencies)
+                cmd="reactive__graph__client__plugins__dependencies"
+                ;;
+            reactive__graph__client__plugins,dependents)
+                cmd="reactive__graph__client__plugins__dependents"
+                ;;
+            reactive__graph__client__plugins,get)
+                cmd="reactive__graph__client__plugins__get"
+                ;;
+            reactive__graph__client__plugins,help)
+                cmd="reactive__graph__client__plugins__help"
+                ;;
+            reactive__graph__client__plugins,list)
+                cmd="reactive__graph__client__plugins__list"
+                ;;
+            reactive__graph__client__plugins,restart)
+                cmd="reactive__graph__client__plugins__restart"
+                ;;
+            reactive__graph__client__plugins,search)
+                cmd="reactive__graph__client__plugins__search"
+                ;;
+            reactive__graph__client__plugins,start)
+                cmd="reactive__graph__client__plugins__start"
+                ;;
+            reactive__graph__client__plugins,stop)
+                cmd="reactive__graph__client__plugins__stop"
+                ;;
+            reactive__graph__client__plugins,uninstall)
+                cmd="reactive__graph__client__plugins__uninstall"
+                ;;
+            reactive__graph__client__plugins__help,dependencies)
+                cmd="reactive__graph__client__plugins__help__dependencies"
+                ;;
+            reactive__graph__client__plugins__help,dependents)
+                cmd="reactive__graph__client__plugins__help__dependents"
+                ;;
+            reactive__graph__client__plugins__help,get)
+                cmd="reactive__graph__client__plugins__help__get"
+                ;;
+            reactive__graph__client__plugins__help,help)
+                cmd="reactive__graph__client__plugins__help__help"
+                ;;
+            reactive__graph__client__plugins__help,list)
+                cmd="reactive__graph__client__plugins__help__list"
+                ;;
+            reactive__graph__client__plugins__help,restart)
+                cmd="reactive__graph__client__plugins__help__restart"
+                ;;
+            reactive__graph__client__plugins__help,search)
+                cmd="reactive__graph__client__plugins__help__search"
+                ;;
+            reactive__graph__client__plugins__help,start)
+                cmd="reactive__graph__client__plugins__help__start"
+                ;;
+            reactive__graph__client__plugins__help,stop)
+                cmd="reactive__graph__client__plugins__help__stop"
+                ;;
+            reactive__graph__client__plugins__help,uninstall)
+                cmd="reactive__graph__client__plugins__help__uninstall"
+                ;;
+            reactive__graph__client__relation__instances,add-component)
+                cmd="reactive__graph__client__relation__instances__add__component"
+                ;;
+            reactive__graph__client__relation__instances,add-property)
+                cmd="reactive__graph__client__relation__instances__add__property"
+                ;;
+            reactive__graph__client__relation__instances,create)
+                cmd="reactive__graph__client__relation__instances__create"
+                ;;
+            reactive__graph__client__relation__instances,delete)
+                cmd="reactive__graph__client__relation__instances__delete"
+                ;;
+            reactive__graph__client__relation__instances,get)
+                cmd="reactive__graph__client__relation__instances__get"
+                ;;
+            reactive__graph__client__relation__instances,get-property)
+                cmd="reactive__graph__client__relation__instances__get__property"
+                ;;
+            reactive__graph__client__relation__instances,help)
+                cmd="reactive__graph__client__relation__instances__help"
+                ;;
+            reactive__graph__client__relation__instances,list)
+                cmd="reactive__graph__client__relation__instances__list"
+                ;;
+            reactive__graph__client__relation__instances,list-components)
+                cmd="reactive__graph__client__relation__instances__list__components"
+                ;;
+            reactive__graph__client__relation__instances,list-properties)
+                cmd="reactive__graph__client__relation__instances__list__properties"
+                ;;
+            reactive__graph__client__relation__instances,remove-component)
+                cmd="reactive__graph__client__relation__instances__remove__component"
+                ;;
+            reactive__graph__client__relation__instances,remove-property)
+                cmd="reactive__graph__client__relation__instances__remove__property"
+                ;;
+            reactive__graph__client__relation__instances,set-property)
+                cmd="reactive__graph__client__relation__instances__set__property"
+                ;;
+            reactive__graph__client__relation__instances__help,add-component)
+                cmd="reactive__graph__client__relation__instances__help__add__component"
+                ;;
+            reactive__graph__client__relation__instances__help,add-property)
+                cmd="reactive__graph__client__relation__instances__help__add__property"
+                ;;
+            reactive__graph__client__relation__instances__help,create)
+                cmd="reactive__graph__client__relation__instances__help__create"
+                ;;
+            reactive__graph__client__relation__instances__help,delete)
+                cmd="reactive__graph__client__relation__instances__help__delete"
+                ;;
+            reactive__graph__client__relation__instances__help,get)
+                cmd="reactive__graph__client__relation__instances__help__get"
+                ;;
+            reactive__graph__client__relation__instances__help,get-property)
+                cmd="reactive__graph__client__relation__instances__help__get__property"
+                ;;
+            reactive__graph__client__relation__instances__help,help)
+                cmd="reactive__graph__client__relation__instances__help__help"
+                ;;
+            reactive__graph__client__relation__instances__help,list)
+                cmd="reactive__graph__client__relation__instances__help__list"
+                ;;
+            reactive__graph__client__relation__instances__help,list-components)
+                cmd="reactive__graph__client__relation__instances__help__list__components"
+                ;;
+            reactive__graph__client__relation__instances__help,list-properties)
+                cmd="reactive__graph__client__relation__instances__help__list__properties"
+                ;;
+            reactive__graph__client__relation__instances__help,remove-component)
+                cmd="reactive__graph__client__relation__instances__help__remove__component"
+                ;;
+            reactive__graph__client__relation__instances__help,remove-property)
+                cmd="reactive__graph__client__relation__instances__help__remove__property"
+                ;;
+            reactive__graph__client__relation__instances__help,set-property)
+                cmd="reactive__graph__client__relation__instances__help__set__property"
+                ;;
+            reactive__graph__client__relation__types,add-component)
+                cmd="reactive__graph__client__relation__types__add__component"
+                ;;
+            reactive__graph__client__relation__types,add-extension)
+                cmd="reactive__graph__client__relation__types__add__extension"
+                ;;
+            reactive__graph__client__relation__types,add-property)
+                cmd="reactive__graph__client__relation__types__add__property"
+                ;;
+            reactive__graph__client__relation__types,create)
+                cmd="reactive__graph__client__relation__types__create"
+                ;;
+            reactive__graph__client__relation__types,delete)
+                cmd="reactive__graph__client__relation__types__delete"
+                ;;
+            reactive__graph__client__relation__types,get)
+                cmd="reactive__graph__client__relation__types__get"
+                ;;
+            reactive__graph__client__relation__types,help)
+                cmd="reactive__graph__client__relation__types__help"
+                ;;
+            reactive__graph__client__relation__types,list)
+                cmd="reactive__graph__client__relation__types__list"
+                ;;
+            reactive__graph__client__relation__types,list-components)
+                cmd="reactive__graph__client__relation__types__list__components"
+                ;;
+            reactive__graph__client__relation__types,list-extensions)
+                cmd="reactive__graph__client__relation__types__list__extensions"
+                ;;
+            reactive__graph__client__relation__types,list-properties)
+                cmd="reactive__graph__client__relation__types__list__properties"
+                ;;
+            reactive__graph__client__relation__types,remove-component)
+                cmd="reactive__graph__client__relation__types__remove__component"
+                ;;
+            reactive__graph__client__relation__types,remove-extension)
+                cmd="reactive__graph__client__relation__types__remove__extension"
+                ;;
+            reactive__graph__client__relation__types,remove-property)
+                cmd="reactive__graph__client__relation__types__remove__property"
+                ;;
+            reactive__graph__client__relation__types,update-description)
+                cmd="reactive__graph__client__relation__types__update__description"
+                ;;
+            reactive__graph__client__relation__types__help,add-component)
+                cmd="reactive__graph__client__relation__types__help__add__component"
+                ;;
+            reactive__graph__client__relation__types__help,add-extension)
+                cmd="reactive__graph__client__relation__types__help__add__extension"
+                ;;
+            reactive__graph__client__relation__types__help,add-property)
+                cmd="reactive__graph__client__relation__types__help__add__property"
+                ;;
+            reactive__graph__client__relation__types__help,create)
+                cmd="reactive__graph__client__relation__types__help__create"
+                ;;
+            reactive__graph__client__relation__types__help,delete)
+                cmd="reactive__graph__client__relation__types__help__delete"
+                ;;
+            reactive__graph__client__relation__types__help,get)
+                cmd="reactive__graph__client__relation__types__help__get"
+                ;;
+            reactive__graph__client__relation__types__help,help)
+                cmd="reactive__graph__client__relation__types__help__help"
+                ;;
+            reactive__graph__client__relation__types__help,list)
+                cmd="reactive__graph__client__relation__types__help__list"
+                ;;
+            reactive__graph__client__relation__types__help,list-components)
+                cmd="reactive__graph__client__relation__types__help__list__components"
+                ;;
+            reactive__graph__client__relation__types__help,list-extensions)
+                cmd="reactive__graph__client__relation__types__help__list__extensions"
+                ;;
+            reactive__graph__client__relation__types__help,list-properties)
+                cmd="reactive__graph__client__relation__types__help__list__properties"
+                ;;
+            reactive__graph__client__relation__types__help,remove-component)
+                cmd="reactive__graph__client__relation__types__help__remove__component"
+                ;;
+            reactive__graph__client__relation__types__help,remove-extension)
+                cmd="reactive__graph__client__relation__types__help__remove__extension"
+                ;;
+            reactive__graph__client__relation__types__help,remove-property)
+                cmd="reactive__graph__client__relation__types__help__remove__property"
+                ;;
+            reactive__graph__client__relation__types__help,update-description)
+                cmd="reactive__graph__client__relation__types__help__update__description"
+                ;;
+            reactive__graph__client__remotes,add)
+                cmd="reactive__graph__client__remotes__add"
+                ;;
+            reactive__graph__client__remotes,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__client__remotes__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__client__remotes,fetch-remotes-from-remote)
+                cmd="reactive__graph__client__remotes__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__client__remotes,help)
+                cmd="reactive__graph__client__remotes__help"
+                ;;
+            reactive__graph__client__remotes,list)
+                cmd="reactive__graph__client__remotes__list"
+                ;;
+            reactive__graph__client__remotes,remove)
+                cmd="reactive__graph__client__remotes__remove"
+                ;;
+            reactive__graph__client__remotes,remove-all)
+                cmd="reactive__graph__client__remotes__remove__all"
+                ;;
+            reactive__graph__client__remotes,update)
+                cmd="reactive__graph__client__remotes__update"
+                ;;
+            reactive__graph__client__remotes,update-all)
+                cmd="reactive__graph__client__remotes__update__all"
+                ;;
+            reactive__graph__client__remotes__help,add)
+                cmd="reactive__graph__client__remotes__help__add"
+                ;;
+            reactive__graph__client__remotes__help,fetch-remotes-from-all-remotes)
+                cmd="reactive__graph__client__remotes__help__fetch__remotes__from__all__remotes"
+                ;;
+            reactive__graph__client__remotes__help,fetch-remotes-from-remote)
+                cmd="reactive__graph__client__remotes__help__fetch__remotes__from__remote"
+                ;;
+            reactive__graph__client__remotes__help,help)
+                cmd="reactive__graph__client__remotes__help__help"
+                ;;
+            reactive__graph__client__remotes__help,list)
+                cmd="reactive__graph__client__remotes__help__list"
+                ;;
+            reactive__graph__client__remotes__help,remove)
+                cmd="reactive__graph__client__remotes__help__remove"
+                ;;
+            reactive__graph__client__remotes__help,remove-all)
+                cmd="reactive__graph__client__remotes__help__remove__all"
+                ;;
+            reactive__graph__client__remotes__help,update)
+                cmd="reactive__graph__client__remotes__help__update"
+                ;;
+            reactive__graph__client__remotes__help,update-all)
+                cmd="reactive__graph__client__remotes__help__update__all"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        reactive__graph__client)
+            opts="-h -V --hostname --port --secure --endpoint-graphql --endpoint-dynamic-graph --endpoint-runtime --endpoint-plugins --bearer --markdown-help --print-shell-completions --install-shell-completions --help --version execute-command instance-info plugins remotes shutdown components entity-types relation-types entity-instances relation-instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-graphql)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-dynamic-graph)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-runtime)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --endpoint-plugins)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --bearer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --print-shell-completions)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --install-shell-completions)
+                    COMPREPLY=($(compgen -W "bash elvish fish powershell zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components)
+            opts="-o -h --output-format --help list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__add__extension)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME> <DESCRIPTION> <EXTENSION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__add__property)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__create)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__delete)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__get)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help)
+            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__list)
+            opts="-o -h --output-format --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__list__extensions)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__list__properties)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__remove__extension)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__remove__property)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__update__description)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <DESCRIPTION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances)
+            opts="-o -h --output-format --help list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__add__component)
+            opts="-o -h --output-format --help <ID> <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__add__property)
+            opts="-o -h --output-format --help <ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__create)
+            opts="-i -d -p -o -h --id --description --properties --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__delete)
+            opts="-o -h --output-format --help <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__get)
+            opts="-o -h --output-format --help <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__get__by__label)
+            opts="-o -h --output-format --help <LABEL>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__get__property)
+            opts="-o -h --output-format --help <ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help)
+            opts="list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__get__by__label)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__help__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__list)
+            opts="-n -i -l -p -c -o -h --namespace --name --id --label --properties --components --output-format --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --namespace)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --components)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__list__components)
+            opts="-o -h --output-format --help <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__list__properties)
+            opts="-o -h --output-format --help <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__remove__component)
+            opts="-o -h --output-format --help <ID> <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__remove__property)
+            opts="-o -h --output-format --help <ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__instances__set__property)
+            opts="-o -h --output-format --help <ID> <NAME> <VALUE>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types)
+            opts="-o -h --output-format --help list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__add__component)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__add__extension)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME> <DESCRIPTION> <EXTENSION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__add__property)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__create)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__delete)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__get)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list)
+            opts="-o -h --output-format --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list__components)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list__extensions)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__list__properties)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__remove__component)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__remove__extension)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__remove__property)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__update__description)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <DESCRIPTION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__execute__command)
+            opts="-h --help <COMMAND_NAME> [COMMAND_ARGUMENTS]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help)
+            opts="execute-command instance-info plugins remotes shutdown components entity-types relation-types entity-instances relation-instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components)
+            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances)
+            opts="list get get-by-label list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__get__by__label)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__instances__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__execute__command)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__instance__info)
+            opts="get"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__instance__info__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins)
+            opts="list search get dependencies dependents start stop restart uninstall"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__dependencies)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__dependents)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__restart)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__search)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__start)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__stop)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__plugins__uninstall)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances)
+            opts="list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__instances__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes)
+            opts="list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__fetch__remotes__from__all__remotes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__fetch__remotes__from__remote)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__remove__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__update)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__remotes__update__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__shutdown)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info)
+            opts="-h --help get help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__get)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__help)
+            opts="get help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__instance__info__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins)
+            opts="-h --help list search get dependencies dependents start stop restart uninstall help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__dependencies)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__dependents)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__get)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help)
+            opts="list search get dependencies dependents start stop restart uninstall help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__dependencies)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__dependents)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__restart)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__search)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__start)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__stop)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__help__uninstall)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__list)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__restart)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__search)
+            opts="-h --name --state --stem --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --state)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --stem)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__start)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__stop)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__plugins__uninstall)
+            opts="-h --help <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances)
+            opts="-o -h --output-format --help list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__add__component)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__add__property)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__create)
+            opts="-i -d -p -o -h --outbound-id --inbound-id --description --properties --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --description)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__delete)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__get)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__get__property)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help)
+            opts="list get list-properties get-property set-property add-property remove-property list-components add-component remove-component create delete help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__get__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__help__set__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__list)
+            opts="-n -i -p -c -o -h --outbound-id --namespace --name --inbound-id --properties --components --output-format --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --namespace)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --properties)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --components)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__list__components)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__list__properties)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__remove__component)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__remove__property)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__instances__set__property)
+            opts="-i -o -h --outbound-id --inbound-id --output-format --help <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <PROPERTY_VALUE>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --outbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --inbound-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types)
+            opts="-o -h --output-format --help list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__add__component)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__add__extension)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME> <DESCRIPTION> <EXTENSION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__add__property)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__create)
+            opts="-o -h --output-format --help <OUTBOUND_TYPE_NAMESPACE> <OUTBOUND_TYPE_NAME> <NAMESPACE> <NAME> <INBOUND_TYPE_NAMESPACE> <INBOUND_TYPE_NAME> [DESCRIPTION]"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__delete)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__get)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help)
+            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__add__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__add__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__add__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__create)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__delete)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list__extensions)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__list__properties)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__remove__component)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__remove__extension)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__remove__property)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list)
+            opts="-o -h --output-format --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list__components)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list__extensions)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__list__properties)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__remove__component)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <COMPONENT_NAMESPACE> <COMPONENT_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__remove__extension)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <EXTENSION_NAMESPACE> <EXTENSION_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__remove__property)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <PROPERTY_NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__update__description)
+            opts="-o -h --output-format --help <NAMESPACE> <NAME> <DESCRIPTION>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes)
+            opts="-h --help list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__add)
+            opts="-h --hostname --port --secure --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__fetch__remotes__from__all__remotes)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__fetch__remotes__from__remote)
+            opts="-h --hostname --port --secure --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help)
+            opts="list add remove remove-all update update-all fetch-remotes-from-remote fetch-remotes-from-all-remotes help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__fetch__remotes__from__all__remotes)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__fetch__remotes__from__remote)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__remove__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__update)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__help__update__all)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__list)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__remove)
+            opts="-h --hostname --port --secure --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__remove__all)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__update)
+            opts="-h --hostname --port --secure --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --hostname)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --port)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --secure)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__remotes__update__all)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__shutdown)
+            opts="-h --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _reactive-graph-client -o nosort -o bashdefault -o default reactive-graph-client
+else
+    complete -F _reactive-graph-client -o bashdefault -o default reactive-graph-client
+fi

--- a/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph.1
+++ b/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph.1
@@ -1,0 +1,236 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH reactive-graph 1  "reactive-graph 0.10.0" 
+.SH NAME
+reactive\-graph \- Reactive Graph Flow
+.SH SYNOPSIS
+\fBreactive\-graph\fR [\fB\-\-logging\-config\fR] [\fB\-\-instance\-config\fR] [\fB\-\-graphql\-config\fR] [\fB\-\-plugins\-config\fR] [\fB\-n\fR|\fB\-\-instance\-name\fR] [\fB\-d\fR|\fB\-\-instance\-description\fR] [\fB\-\-hostname\fR] [\fB\-\-port\fR] [\fB\-\-secure\fR] [\fB\-\-ssl\-certificate\-path\fR] [\fB\-\-ssl\-private\-key\-path\fR] [\fB\-\-shutdown\-timeout\fR] [\fB\-w\fR|\fB\-\-workers\fR] [\fB\-c\fR|\fB\-\-default\-context\-path\fR] [\fB\-x\fR|\fB\-\-disable\-all\-plugins\fR] [\fB\-p\fR|\fB\-\-disabled\-plugins\fR] [\fB\-P\fR|\fB\-\-enabled\-plugins\fR] [\fB\-\-disable\-hot\-deploy\fR] [\fB\-\-hot\-deploy\-location\fR] [\fB\-\-install\-location\fR] [\fB\-\-stop\-immediately\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-print\-shell\-completions\fR] [\fB\-\-install\-shell\-completions\fR] [\fB\-D\fR|\fB\-\-daemon\fR] [\fB\-\-daemon\-name\fR] [\fB\-\-daemon\-pid\fR] [\fB\-\-daemon\-working\-directory\fR] [\fB\-\-daemon\-stdout\fR] [\fB\-\-daemon\-stderr\fR] [\fB\-\-daemon\-user\fR] [\fB\-\-daemon\-group\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+.SH DESCRIPTION
+Reactive Graph Flow
+.SH OPTIONS
+.TP
+\fB\-\-logging\-config\fR=\fILOGGING_CONFIG\fR
+The logging config location
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_LOGGING_CONFIG\fR environment variable. 
+.RE
+.TP
+\fB\-\-instance\-config\fR=\fIINSTANCE_CONFIG\fR
+The instance config location
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_CONFIG\fR environment variable. 
+.RE
+.TP
+\fB\-\-graphql\-config\fR=\fIGRAPHQL_CONFIG\fR
+The GraphQL config location
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_GRAPHQL_CONFIG\fR environment variable. 
+.RE
+.TP
+\fB\-\-plugins\-config\fR=\fIPLUGINS_CONFIG\fR
+The plugins config location
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_PLUGINS_CONFIG\fR environment variable. 
+.RE
+.TP
+\fB\-n\fR, \fB\-\-instance\-name\fR=\fIINSTANCE_NAME\fR
+The name of the instance
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_NAME\fR environment variable. 
+.RE
+.TP
+\fB\-d\fR, \fB\-\-instance\-description\fR=\fIINSTANCE_DESCRIPTION\fR
+The description of the instance
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_DESCRIPTION\fR environment variable. 
+.RE
+.TP
+\fB\-\-hostname\fR=\fIHOSTNAME\fR
+The hostname to bind the GraphQL HTTP server
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_HOSTNAME\fR environment variable. 
+.RE
+.TP
+\fB\-\-port\fR=\fIPORT\fR
+The port to bind the GraphQL HTTP server
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_PORT\fR environment variable. 
+.RE
+.TP
+\fB\-\-secure\fR=\fISECURE\fR
+If true, HTTPS is enabled
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_SECURE\fR environment variable. 
+.RE
+.TP
+\fB\-\-ssl\-certificate\-path\fR=\fISSL_CERTIFICATE_PATH\fR
+The location of the certificate
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_SSL_CERTIFICATE_PATH\fR environment variable. 
+.RE
+.TP
+\fB\-\-ssl\-private\-key\-path\fR=\fISSL_PRIVATE_KEY_PATH\fR
+The location of the private key
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_SSL_PRIVATE_KEY_PATH\fR environment variable. 
+.RE
+.TP
+\fB\-\-shutdown\-timeout\fR=\fISHUTDOWN_TIMEOUT\fR
+Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_SHUTDOWN_TIMEOUT\fR environment variable. 
+.RE
+.TP
+\fB\-w\fR, \fB\-\-workers\fR=\fIWORKERS\fR
+The number of workers to start. The default worker count is the number of physical CPU cores available
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_WORKERS\fR environment variable. 
+.RE
+.TP
+\fB\-c\fR, \fB\-\-default\-context\-path\fR=\fIDEFAULT_CONTEXT_PATH\fR
+The default context path which redirects the root context to a web resource provider
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DEFAULT_CONTEXT_PATH\fR environment variable. 
+.RE
+.TP
+\fB\-x\fR, \fB\-\-disable\-all\-plugins\fR=\fIDISABLE_ALL_PLUGINS\fR
+If true, all plugins will be disabled
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DISABLE_ALL_PLUGINS\fR environment variable. 
+.RE
+.TP
+\fB\-p\fR, \fB\-\-disabled\-plugins\fR=\fIDISABLED_PLUGINS\fR
+The list of plugins to disable
+.TP
+\fB\-P\fR, \fB\-\-enabled\-plugins\fR=\fIENABLED_PLUGINS\fR
+The list of plugins to enable
+.TP
+\fB\-\-disable\-hot\-deploy\fR=\fIDISABLE_HOT_DEPLOY\fR
+If true, hot deployment will be disabled
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DISABLE_HOT_DEPLOY\fR environment variable. 
+.RE
+.TP
+\fB\-\-hot\-deploy\-location\fR=\fIHOT_DEPLOY_LOCATION\fR
+The folder which is watched for hot deployment
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_HOT_DEPLOY_LOCATION\fR environment variable. 
+.RE
+.TP
+\fB\-\-install\-location\fR=\fIINSTALL_LOCATION\fR
+The folder which plugins are installed permanently
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_INSTALL_LOCATION\fR environment variable. 
+.RE
+.TP
+\fB\-\-stop\-immediately\fR=\fISTOP_IMMEDIATELY\fR
+If true, the runtime does not wait before exiting
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_STOP_IMMEDIATELY\fR environment variable. 
+.RE
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR=\fIQUIET\fR
+If true, logging is disabled completely
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_QUIET\fR environment variable. 
+.RE
+.TP
+\fB\-\-print\-shell\-completions\fR=\fIPRINT_SHELL_COMPLETIONS\fR
+If true, prints shell completions
+.br
+
+.br
+[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+.TP
+\fB\-\-install\-shell\-completions\fR=\fIINSTALL_SHELL_COMPLETIONS\fR
+If true, installs shell completions
+.br
+
+.br
+[\fIpossible values: \fRbash, elvish, fish, powershell, zsh]
+.TP
+\fB\-D\fR, \fB\-\-daemon\fR
+If true, the process will run as daemon
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-name\fR=\fIDAEMON_NAME\fR
+Sets the name of the daemon
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_NAME\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-pid\fR=\fIDAEMON_PID\fR
+The location of the daemon PID file. By default, no PID file will be created
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_PID\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-working\-directory\fR=\fIDAEMON_WORKING_DIRECTORY\fR
+The working directory of the daemon
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_WORKING_DIRECTORY\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-stdout\fR=\fIDAEMON_STDOUT\fR
+Stdout will be written into this file
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_STDOUT\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-stderr\fR=\fIDAEMON_STDERR\fR
+Stderr will be written into this file
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_STDERR\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-user\fR=\fIDAEMON_USER\fR
+If set will drop privileges to the specified user. Note: Both must be given: user and group
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_USER\fR environment variable. 
+.RE
+.TP
+\fB\-\-daemon\-group\fR=\fIDAEMON_GROUP\fR
+If set will drop privileges to the specified group. Note: Both must be given: user and group
+.RS
+May also be specified with the \fBREACTIVE_GRAPH_DAEMON_GROUP\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+reactive\-graph\-client(1)
+Connects to a client
+.TP
+reactive\-graph\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v0.10.0
+.SH AUTHORS
+Andreas Schaeffer <hanack@nooblounge.net>
+

--- a/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph
+++ b/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph
@@ -1,0 +1,5164 @@
+#compdef reactive-graph
+
+autoload -U is-at-least
+
+_reactive-graph() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'--logging-config=[The logging config location]:LOGGING_CONFIG: ' \
+'--instance-config=[The instance config location]:INSTANCE_CONFIG: ' \
+'--graphql-config=[The GraphQL config location]:GRAPHQL_CONFIG: ' \
+'--plugins-config=[The plugins config location]:PLUGINS_CONFIG: ' \
+'-n+[The name of the instance]:INSTANCE_NAME: ' \
+'--instance-name=[The name of the instance]:INSTANCE_NAME: ' \
+'-d+[The description of the instance]:INSTANCE_DESCRIPTION: ' \
+'--instance-description=[The description of the instance]:INSTANCE_DESCRIPTION: ' \
+'--hostname=[The hostname to bind the GraphQL HTTP server]:HOSTNAME: ' \
+'--port=[The port to bind the GraphQL HTTP server]:PORT: ' \
+'--secure=[If true, HTTPS is enabled]:SECURE:(true false)' \
+'--ssl-certificate-path=[The location of the certificate]:SSL_CERTIFICATE_PATH: ' \
+'--ssl-private-key-path=[The location of the private key]:SSL_PRIVATE_KEY_PATH: ' \
+'--shutdown-timeout=[Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds]:SHUTDOWN_TIMEOUT: ' \
+'-w+[The number of workers to start. The default worker count is the number of physical CPU cores available]:WORKERS: ' \
+'--workers=[The number of workers to start. The default worker count is the number of physical CPU cores available]:WORKERS: ' \
+'-c+[The default context path which redirects the root context to a web resource provider]:DEFAULT_CONTEXT_PATH: ' \
+'--default-context-path=[The default context path which redirects the root context to a web resource provider]:DEFAULT_CONTEXT_PATH: ' \
+'-x+[If true, all plugins will be disabled]:DISABLE_ALL_PLUGINS:(true false)' \
+'--disable-all-plugins=[If true, all plugins will be disabled]:DISABLE_ALL_PLUGINS:(true false)' \
+'*-p+[The list of plugins to disable]:DISABLED_PLUGINS: ' \
+'*--disabled-plugins=[The list of plugins to disable]:DISABLED_PLUGINS: ' \
+'*-P+[The list of plugins to enable]:ENABLED_PLUGINS: ' \
+'*--enabled-plugins=[The list of plugins to enable]:ENABLED_PLUGINS: ' \
+'--disable-hot-deploy=[If true, hot deployment will be disabled]:DISABLE_HOT_DEPLOY:(true false)' \
+'--hot-deploy-location=[The folder which is watched for hot deployment]:HOT_DEPLOY_LOCATION: ' \
+'--install-location=[The folder which plugins are installed permanently]:INSTALL_LOCATION: ' \
+'--stop-immediately=[If true, the runtime does not wait before exiting]:STOP_IMMEDIATELY:(true false)' \
+'-q+[If true, logging is disabled completely]:QUIET:(true false)' \
+'--quiet=[If true, logging is disabled completely]:QUIET:(true false)' \
+'--print-shell-completions=[If true, prints shell completions]:PRINT_SHELL_COMPLETIONS:(bash elvish fish powershell zsh)' \
+'--install-shell-completions=[If true, installs shell completions]:INSTALL_SHELL_COMPLETIONS:(bash elvish fish powershell zsh)' \
+'--daemon-name=[Sets the name of the daemon]:DAEMON_NAME: ' \
+'--daemon-pid=[The location of the daemon PID file. By default, no PID file will be created]:DAEMON_PID: ' \
+'--daemon-working-directory=[The working directory of the daemon]:DAEMON_WORKING_DIRECTORY: ' \
+'--daemon-stdout=[Stdout will be written into this file]:DAEMON_STDOUT: ' \
+'--daemon-stderr=[Stderr will be written into this file]:DAEMON_STDERR: ' \
+'--daemon-user=[If set will drop privileges to the specified user. Note\: Both must be given\: user and group]:DAEMON_USER: ' \
+'--daemon-group=[If set will drop privileges to the specified group. Note\: Both must be given\: user and group]:DAEMON_GROUP: ' \
+'--markdown-help[If true, generates command line documentation]' \
+'-D[If true, the process will run as daemon]' \
+'--daemon[If true, the process will run as daemon]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph_commands" \
+"*::: :->reactive-graph" \
+&& ret=0
+    case $state in
+    (reactive-graph)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-command-$line[1]:"
+        case $line[1] in
+            (client)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname to connect to]:HOSTNAME: ' \
+'--port=[The port to connect to]:PORT: ' \
+'--secure=[If true, connects via HTTPS]:SECURE:(true false)' \
+'--endpoint-graphql=[The endpoint to use]:ENDPOINT_GRAPHQL: ' \
+'--endpoint-dynamic-graph=[The endpoint to use]:ENDPOINT_DYNAMIC_GRAPH: ' \
+'--endpoint-runtime=[The endpoint to use]:ENDPOINT_RUNTIME: ' \
+'--endpoint-plugins=[The endpoint to use]:ENDPOINT_PLUGINS: ' \
+'--bearer=[The authentication token]:BEARER: ' \
+'--print-shell-completions=[If true, prints shell completions]:PRINT_SHELL_COMPLETIONS:(bash elvish fish powershell zsh)' \
+'--install-shell-completions=[If true, installs shell completions]:INSTALL_SHELL_COMPLETIONS:(bash elvish fish powershell zsh)' \
+'--markdown-help[If true, generates command line documentation]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client_commands" \
+"*::: :->client" \
+&& ret=0
+
+    case $state in
+    (client)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-command-$line[1]:"
+        case $line[1] in
+            (execute-command)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':command_name -- The command name:' \
+'*::command_arguments -- The command arguments:' \
+&& ret=0
+;;
+(instance-info)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__instance-info_commands" \
+"*::: :->instance-info" \
+&& ret=0
+
+    case $state in
+    (instance-info)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-instance-info-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__instance-info__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-instance-info-help-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(plugins)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__plugins_commands" \
+"*::: :->plugins" \
+&& ret=0
+
+    case $state in
+    (plugins)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-plugins-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+'--name=[The plugin name]:NAME: ' \
+'--state=[The plugin state]:STATE: ' \
+'--stem=[The plugin file stem]:STEM: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__plugins__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-plugins-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(remotes)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__remotes_commands" \
+"*::: :->remotes" \
+&& ret=0
+
+    case $state in
+    (remotes)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-remotes-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__remotes__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-remotes-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__components_commands" \
+"*::: :->components" \
+&& ret=0
+
+    case $state in
+    (components)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-components-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+'::description -- The component description:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+':description -- Textual description of the extension:' \
+':extension -- The extension as JSON representation:' \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':description -- The description to update:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__components__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-components-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(entity-types)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__entity-types_commands" \
+"*::: :->entity-types" \
+&& ret=0
+
+    case $state in
+    (entity-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+'::description -- The entity type description:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+':description -- Textual description of the extension:' \
+':extension -- The extension as JSON representation:' \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':description -- The description to update:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__entity-types__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-types-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(relation-types)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__relation-types_commands" \
+"*::: :->relation-types" \
+&& ret=0
+
+    case $state in
+    (relation-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':outbound_type_namespace -- The outbound entity type namespace:' \
+':outbound_type_name -- The outbound entity type name:' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':inbound_type_namespace -- The inbound entity type namespace:' \
+':inbound_type_name -- The inbound entity type name:' \
+'::description -- The relation type description:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+':description -- Textual description of the extension:' \
+':extension -- The extension as JSON representation:' \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':description -- The description to update:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__relation-types__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-types-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(entity-instances)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__entity-instances_commands" \
+"*::: :->entity-instances" \
+&& ret=0
+
+    case $state in
+    (entity-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'--namespace=[The entity type namespace]:NAMESPACE: ' \
+'-n+[The entity type name]:NAME: ' \
+'--name=[The entity type name]:NAME: ' \
+'-i+[The id of the entity instance]:ID: ' \
+'--id=[The id of the entity instance]:ID: ' \
+'-l+[The label of the entity instance]:LABEL: ' \
+'--label=[The label of the entity instance]:LABEL: ' \
+'*-p+[The properties to search for]:PROPERTIES: ' \
+'*--properties=[The properties to search for]:PROPERTIES: ' \
+'*-c+[The components to search for]:COMPONENTS: ' \
+'*--components=[The components to search for]:COMPONENTS: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':label -- The label of the reactive instance:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the entity instance:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the reactive instance:' \
+':name -- The name of the property:' \
+':value -- The new JSON value of the property:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the reactive instance:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the entity instance:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the reactive instance:' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the reactive instance:' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-i+[The entity instance id]:ID: ' \
+'--id=[The entity instance id]:ID: ' \
+'-d+[The entity instance description]:DESCRIPTION: ' \
+'--description=[The entity instance description]:DESCRIPTION: ' \
+'*-p+[The entity instance properties]:PROPERTIES: ' \
+'*--properties=[The entity instance properties]:PROPERTIES: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__entity-instances__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-instances-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(relation-instances)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__client__relation-instances_commands" \
+"*::: :->relation-instances" \
+&& ret=0
+
+    case $state in
+    (relation-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'--namespace=[The relation type namespace]:NAMESPACE: ' \
+'-n+[The relation type name]:NAME: ' \
+'--name=[The relation type name]:NAME: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'*-p+[The properties to search for]:PROPERTIES: ' \
+'*--properties=[The properties to search for]:PROPERTIES: ' \
+'*-c+[The components to search for]:COMPONENTS: ' \
+'*--components=[The components to search for]:COMPONENTS: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+':property_value -- The JSON value of the property:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-d+[The relation instance description]:DESCRIPTION: ' \
+'--description=[The relation instance description]:DESCRIPTION: ' \
+'*-p+[The relation instance properties]:PROPERTIES: ' \
+'*--properties=[The relation instance properties]:PROPERTIES: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__relation-instances__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-instances-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-command-$line[1]:"
+        case $line[1] in
+            (execute-command)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(instance-info)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__instance-info_commands" \
+"*::: :->instance-info" \
+&& ret=0
+
+    case $state in
+    (instance-info)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-instance-info-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(plugins)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__plugins_commands" \
+"*::: :->plugins" \
+&& ret=0
+
+    case $state in
+    (plugins)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-plugins-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(remotes)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__remotes_commands" \
+"*::: :->remotes" \
+&& ret=0
+
+    case $state in
+    (remotes)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-remotes-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(components)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__components_commands" \
+"*::: :->components" \
+&& ret=0
+
+    case $state in
+    (components)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-components-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(entity-types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__entity-types_commands" \
+"*::: :->entity-types" \
+&& ret=0
+
+    case $state in
+    (entity-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-entity-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(relation-types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__relation-types_commands" \
+"*::: :->relation-types" \
+&& ret=0
+
+    case $state in
+    (relation-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-relation-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(entity-instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__entity-instances_commands" \
+"*::: :->entity-instances" \
+&& ret=0
+
+    case $state in
+    (entity-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-entity-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(relation-instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__client__help__relation-instances_commands" \
+"*::: :->relation-instances" \
+&& ret=0
+
+    case $state in
+    (relation-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-relation-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-command-$line[1]:"
+        case $line[1] in
+            (client)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client_commands" \
+"*::: :->client" \
+&& ret=0
+
+    case $state in
+    (client)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-command-$line[1]:"
+        case $line[1] in
+            (execute-command)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(instance-info)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__instance-info_commands" \
+"*::: :->instance-info" \
+&& ret=0
+
+    case $state in
+    (instance-info)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-instance-info-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(plugins)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__plugins_commands" \
+"*::: :->plugins" \
+&& ret=0
+
+    case $state in
+    (plugins)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-plugins-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(remotes)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__remotes_commands" \
+"*::: :->remotes" \
+&& ret=0
+
+    case $state in
+    (remotes)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-remotes-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(components)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__components_commands" \
+"*::: :->components" \
+&& ret=0
+
+    case $state in
+    (components)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-components-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(entity-types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__entity-types_commands" \
+"*::: :->entity-types" \
+&& ret=0
+
+    case $state in
+    (entity-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-entity-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(relation-types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__relation-types_commands" \
+"*::: :->relation-types" \
+&& ret=0
+
+    case $state in
+    (relation-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-relation-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(entity-instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__entity-instances_commands" \
+"*::: :->entity-instances" \
+&& ret=0
+
+    case $state in
+    (entity-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-entity-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(relation-instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__client__relation-instances_commands" \
+"*::: :->relation-instances" \
+&& ret=0
+
+    case $state in
+    (relation-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-client-relation-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_reactive-graph_commands] )) ||
+_reactive-graph_commands() {
+    local commands; commands=(
+'client:Connects to a client' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client_commands] )) ||
+_reactive-graph__client_commands() {
+    local commands; commands=(
+'execute-command:Executes a command on the client' \
+'instance-info:Prints information about the instance' \
+'plugins:Manage plugins' \
+'remotes:Manage remotes' \
+'shutdown:Shutdown the runtime' \
+'components:Manage components' \
+'entity-types:Manage entity types' \
+'relation-types:Manage entity types' \
+'entity-instances:Manage entity instances' \
+'relation-instances:Manage relation instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components_commands] )) ||
+_reactive-graph__client__components_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__add-extension_commands] )) ||
+_reactive-graph__client__components__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__add-property_commands] )) ||
+_reactive-graph__client__components__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__create_commands] )) ||
+_reactive-graph__client__components__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__delete_commands] )) ||
+_reactive-graph__client__components__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__get_commands] )) ||
+_reactive-graph__client__components__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help_commands] )) ||
+_reactive-graph__client__components__help_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client components help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__add-extension_commands] )) ||
+_reactive-graph__client__components__help__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__add-property_commands] )) ||
+_reactive-graph__client__components__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__create_commands] )) ||
+_reactive-graph__client__components__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__delete_commands] )) ||
+_reactive-graph__client__components__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__get_commands] )) ||
+_reactive-graph__client__components__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__help_commands] )) ||
+_reactive-graph__client__components__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__list_commands] )) ||
+_reactive-graph__client__components__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__list-extensions_commands] )) ||
+_reactive-graph__client__components__help__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__list-properties_commands] )) ||
+_reactive-graph__client__components__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__remove-extension_commands] )) ||
+_reactive-graph__client__components__help__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__remove-property_commands] )) ||
+_reactive-graph__client__components__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__help__update-description_commands] )) ||
+_reactive-graph__client__components__help__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components help update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__list_commands] )) ||
+_reactive-graph__client__components__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__list-extensions_commands] )) ||
+_reactive-graph__client__components__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__list-properties_commands] )) ||
+_reactive-graph__client__components__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__remove-extension_commands] )) ||
+_reactive-graph__client__components__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__remove-property_commands] )) ||
+_reactive-graph__client__components__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__components__update-description_commands] )) ||
+_reactive-graph__client__components__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client components update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances_commands] )) ||
+_reactive-graph__client__entity-instances_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client entity-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__add-component_commands] )) ||
+_reactive-graph__client__entity-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__add-property_commands] )) ||
+_reactive-graph__client__entity-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__create_commands] )) ||
+_reactive-graph__client__entity-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__delete_commands] )) ||
+_reactive-graph__client__entity-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__get_commands] )) ||
+_reactive-graph__client__entity-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__get-by-label_commands] )) ||
+_reactive-graph__client__entity-instances__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__get-property_commands] )) ||
+_reactive-graph__client__entity-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help_commands] )) ||
+_reactive-graph__client__entity-instances__help_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client entity-instances help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__add-component_commands] )) ||
+_reactive-graph__client__entity-instances__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__add-property_commands] )) ||
+_reactive-graph__client__entity-instances__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__create_commands] )) ||
+_reactive-graph__client__entity-instances__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__delete_commands] )) ||
+_reactive-graph__client__entity-instances__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__get_commands] )) ||
+_reactive-graph__client__entity-instances__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__get-by-label_commands] )) ||
+_reactive-graph__client__entity-instances__help__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__get-property_commands] )) ||
+_reactive-graph__client__entity-instances__help__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__help_commands] )) ||
+_reactive-graph__client__entity-instances__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__list_commands] )) ||
+_reactive-graph__client__entity-instances__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__list-components_commands] )) ||
+_reactive-graph__client__entity-instances__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__list-properties_commands] )) ||
+_reactive-graph__client__entity-instances__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__remove-component_commands] )) ||
+_reactive-graph__client__entity-instances__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__remove-property_commands] )) ||
+_reactive-graph__client__entity-instances__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__help__set-property_commands] )) ||
+_reactive-graph__client__entity-instances__help__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances help set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__list_commands] )) ||
+_reactive-graph__client__entity-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__list-components_commands] )) ||
+_reactive-graph__client__entity-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__list-properties_commands] )) ||
+_reactive-graph__client__entity-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__remove-component_commands] )) ||
+_reactive-graph__client__entity-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__remove-property_commands] )) ||
+_reactive-graph__client__entity-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-instances__set-property_commands] )) ||
+_reactive-graph__client__entity-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types_commands] )) ||
+_reactive-graph__client__entity-types_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client entity-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__add-component_commands] )) ||
+_reactive-graph__client__entity-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__add-extension_commands] )) ||
+_reactive-graph__client__entity-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__add-property_commands] )) ||
+_reactive-graph__client__entity-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__create_commands] )) ||
+_reactive-graph__client__entity-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__delete_commands] )) ||
+_reactive-graph__client__entity-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__get_commands] )) ||
+_reactive-graph__client__entity-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help_commands] )) ||
+_reactive-graph__client__entity-types__help_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client entity-types help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__add-component_commands] )) ||
+_reactive-graph__client__entity-types__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__add-extension_commands] )) ||
+_reactive-graph__client__entity-types__help__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__add-property_commands] )) ||
+_reactive-graph__client__entity-types__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__create_commands] )) ||
+_reactive-graph__client__entity-types__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__delete_commands] )) ||
+_reactive-graph__client__entity-types__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__get_commands] )) ||
+_reactive-graph__client__entity-types__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__help_commands] )) ||
+_reactive-graph__client__entity-types__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__list_commands] )) ||
+_reactive-graph__client__entity-types__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__list-components_commands] )) ||
+_reactive-graph__client__entity-types__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__list-extensions_commands] )) ||
+_reactive-graph__client__entity-types__help__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__list-properties_commands] )) ||
+_reactive-graph__client__entity-types__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__remove-component_commands] )) ||
+_reactive-graph__client__entity-types__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__remove-extension_commands] )) ||
+_reactive-graph__client__entity-types__help__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__remove-property_commands] )) ||
+_reactive-graph__client__entity-types__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__help__update-description_commands] )) ||
+_reactive-graph__client__entity-types__help__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types help update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__list_commands] )) ||
+_reactive-graph__client__entity-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__list-components_commands] )) ||
+_reactive-graph__client__entity-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__list-extensions_commands] )) ||
+_reactive-graph__client__entity-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__list-properties_commands] )) ||
+_reactive-graph__client__entity-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__remove-component_commands] )) ||
+_reactive-graph__client__entity-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__remove-extension_commands] )) ||
+_reactive-graph__client__entity-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__remove-property_commands] )) ||
+_reactive-graph__client__entity-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__entity-types__update-description_commands] )) ||
+_reactive-graph__client__entity-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client entity-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__execute-command_commands] )) ||
+_reactive-graph__client__execute-command_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client execute-command commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help_commands] )) ||
+_reactive-graph__client__help_commands() {
+    local commands; commands=(
+'execute-command:Executes a command on the client' \
+'instance-info:Prints information about the instance' \
+'plugins:Manage plugins' \
+'remotes:Manage remotes' \
+'shutdown:Shutdown the runtime' \
+'components:Manage components' \
+'entity-types:Manage entity types' \
+'relation-types:Manage entity types' \
+'entity-instances:Manage entity instances' \
+'relation-instances:Manage relation instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components_commands] )) ||
+_reactive-graph__client__help__components_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+    )
+    _describe -t commands 'reactive-graph client help components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__add-extension_commands] )) ||
+_reactive-graph__client__help__components__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__add-property_commands] )) ||
+_reactive-graph__client__help__components__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__create_commands] )) ||
+_reactive-graph__client__help__components__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__delete_commands] )) ||
+_reactive-graph__client__help__components__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__get_commands] )) ||
+_reactive-graph__client__help__components__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__list_commands] )) ||
+_reactive-graph__client__help__components__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__list-extensions_commands] )) ||
+_reactive-graph__client__help__components__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__list-properties_commands] )) ||
+_reactive-graph__client__help__components__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__remove-extension_commands] )) ||
+_reactive-graph__client__help__components__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__remove-property_commands] )) ||
+_reactive-graph__client__help__components__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__components__update-description_commands] )) ||
+_reactive-graph__client__help__components__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help components update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances_commands] )) ||
+_reactive-graph__client__help__entity-instances_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+    )
+    _describe -t commands 'reactive-graph client help entity-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__add-component_commands] )) ||
+_reactive-graph__client__help__entity-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__add-property_commands] )) ||
+_reactive-graph__client__help__entity-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__create_commands] )) ||
+_reactive-graph__client__help__entity-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__delete_commands] )) ||
+_reactive-graph__client__help__entity-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__get_commands] )) ||
+_reactive-graph__client__help__entity-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__get-by-label_commands] )) ||
+_reactive-graph__client__help__entity-instances__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__get-property_commands] )) ||
+_reactive-graph__client__help__entity-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__list_commands] )) ||
+_reactive-graph__client__help__entity-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__list-components_commands] )) ||
+_reactive-graph__client__help__entity-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__list-properties_commands] )) ||
+_reactive-graph__client__help__entity-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__remove-component_commands] )) ||
+_reactive-graph__client__help__entity-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__remove-property_commands] )) ||
+_reactive-graph__client__help__entity-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-instances__set-property_commands] )) ||
+_reactive-graph__client__help__entity-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types_commands] )) ||
+_reactive-graph__client__help__entity-types_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+    )
+    _describe -t commands 'reactive-graph client help entity-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__add-component_commands] )) ||
+_reactive-graph__client__help__entity-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__add-extension_commands] )) ||
+_reactive-graph__client__help__entity-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__add-property_commands] )) ||
+_reactive-graph__client__help__entity-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__create_commands] )) ||
+_reactive-graph__client__help__entity-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__delete_commands] )) ||
+_reactive-graph__client__help__entity-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__get_commands] )) ||
+_reactive-graph__client__help__entity-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__list_commands] )) ||
+_reactive-graph__client__help__entity-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__list-components_commands] )) ||
+_reactive-graph__client__help__entity-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__list-extensions_commands] )) ||
+_reactive-graph__client__help__entity-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__list-properties_commands] )) ||
+_reactive-graph__client__help__entity-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__remove-component_commands] )) ||
+_reactive-graph__client__help__entity-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__remove-extension_commands] )) ||
+_reactive-graph__client__help__entity-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__remove-property_commands] )) ||
+_reactive-graph__client__help__entity-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__entity-types__update-description_commands] )) ||
+_reactive-graph__client__help__entity-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help entity-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__execute-command_commands] )) ||
+_reactive-graph__client__help__execute-command_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help execute-command commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__help_commands] )) ||
+_reactive-graph__client__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__instance-info_commands] )) ||
+_reactive-graph__client__help__instance-info_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+    )
+    _describe -t commands 'reactive-graph client help instance-info commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__instance-info__get_commands] )) ||
+_reactive-graph__client__help__instance-info__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help instance-info get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins_commands] )) ||
+_reactive-graph__client__help__plugins_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+    )
+    _describe -t commands 'reactive-graph client help plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__dependencies_commands] )) ||
+_reactive-graph__client__help__plugins__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__dependents_commands] )) ||
+_reactive-graph__client__help__plugins__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__get_commands] )) ||
+_reactive-graph__client__help__plugins__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__list_commands] )) ||
+_reactive-graph__client__help__plugins__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__restart_commands] )) ||
+_reactive-graph__client__help__plugins__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__search_commands] )) ||
+_reactive-graph__client__help__plugins__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins search commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__start_commands] )) ||
+_reactive-graph__client__help__plugins__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins start commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__stop_commands] )) ||
+_reactive-graph__client__help__plugins__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__plugins__uninstall_commands] )) ||
+_reactive-graph__client__help__plugins__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help plugins uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances_commands] )) ||
+_reactive-graph__client__help__relation-instances_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+    )
+    _describe -t commands 'reactive-graph client help relation-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__add-component_commands] )) ||
+_reactive-graph__client__help__relation-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__add-property_commands] )) ||
+_reactive-graph__client__help__relation-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__create_commands] )) ||
+_reactive-graph__client__help__relation-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__delete_commands] )) ||
+_reactive-graph__client__help__relation-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__get_commands] )) ||
+_reactive-graph__client__help__relation-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__get-property_commands] )) ||
+_reactive-graph__client__help__relation-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__list_commands] )) ||
+_reactive-graph__client__help__relation-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__list-components_commands] )) ||
+_reactive-graph__client__help__relation-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__list-properties_commands] )) ||
+_reactive-graph__client__help__relation-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__remove-component_commands] )) ||
+_reactive-graph__client__help__relation-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__remove-property_commands] )) ||
+_reactive-graph__client__help__relation-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-instances__set-property_commands] )) ||
+_reactive-graph__client__help__relation-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types_commands] )) ||
+_reactive-graph__client__help__relation-types_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+    )
+    _describe -t commands 'reactive-graph client help relation-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__add-component_commands] )) ||
+_reactive-graph__client__help__relation-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__add-extension_commands] )) ||
+_reactive-graph__client__help__relation-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__add-property_commands] )) ||
+_reactive-graph__client__help__relation-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__create_commands] )) ||
+_reactive-graph__client__help__relation-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__delete_commands] )) ||
+_reactive-graph__client__help__relation-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__get_commands] )) ||
+_reactive-graph__client__help__relation-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__list_commands] )) ||
+_reactive-graph__client__help__relation-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__list-components_commands] )) ||
+_reactive-graph__client__help__relation-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__list-extensions_commands] )) ||
+_reactive-graph__client__help__relation-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__list-properties_commands] )) ||
+_reactive-graph__client__help__relation-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__remove-component_commands] )) ||
+_reactive-graph__client__help__relation-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__remove-extension_commands] )) ||
+_reactive-graph__client__help__relation-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__remove-property_commands] )) ||
+_reactive-graph__client__help__relation-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__relation-types__update-description_commands] )) ||
+_reactive-graph__client__help__relation-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help relation-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes_commands] )) ||
+_reactive-graph__client__help__remotes_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+    )
+    _describe -t commands 'reactive-graph client help remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__add_commands] )) ||
+_reactive-graph__client__help__remotes__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes add commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph__client__help__remotes__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph__client__help__remotes__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__list_commands] )) ||
+_reactive-graph__client__help__remotes__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__remove_commands] )) ||
+_reactive-graph__client__help__remotes__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__remove-all_commands] )) ||
+_reactive-graph__client__help__remotes__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__update_commands] )) ||
+_reactive-graph__client__help__remotes__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes update commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__remotes__update-all_commands] )) ||
+_reactive-graph__client__help__remotes__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help remotes update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__help__shutdown_commands] )) ||
+_reactive-graph__client__help__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client help shutdown commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__instance-info_commands] )) ||
+_reactive-graph__client__instance-info_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client instance-info commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__instance-info__get_commands] )) ||
+_reactive-graph__client__instance-info__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client instance-info get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__instance-info__help_commands] )) ||
+_reactive-graph__client__instance-info__help_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client instance-info help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__instance-info__help__get_commands] )) ||
+_reactive-graph__client__instance-info__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client instance-info help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__instance-info__help__help_commands] )) ||
+_reactive-graph__client__instance-info__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client instance-info help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins_commands] )) ||
+_reactive-graph__client__plugins_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__dependencies_commands] )) ||
+_reactive-graph__client__plugins__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__dependents_commands] )) ||
+_reactive-graph__client__plugins__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__get_commands] )) ||
+_reactive-graph__client__plugins__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help_commands] )) ||
+_reactive-graph__client__plugins__help_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client plugins help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__dependencies_commands] )) ||
+_reactive-graph__client__plugins__help__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__dependents_commands] )) ||
+_reactive-graph__client__plugins__help__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__get_commands] )) ||
+_reactive-graph__client__plugins__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__help_commands] )) ||
+_reactive-graph__client__plugins__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__list_commands] )) ||
+_reactive-graph__client__plugins__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__restart_commands] )) ||
+_reactive-graph__client__plugins__help__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__search_commands] )) ||
+_reactive-graph__client__plugins__help__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help search commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__start_commands] )) ||
+_reactive-graph__client__plugins__help__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help start commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__stop_commands] )) ||
+_reactive-graph__client__plugins__help__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__help__uninstall_commands] )) ||
+_reactive-graph__client__plugins__help__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins help uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__list_commands] )) ||
+_reactive-graph__client__plugins__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__restart_commands] )) ||
+_reactive-graph__client__plugins__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__search_commands] )) ||
+_reactive-graph__client__plugins__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins search commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__start_commands] )) ||
+_reactive-graph__client__plugins__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins start commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__stop_commands] )) ||
+_reactive-graph__client__plugins__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__plugins__uninstall_commands] )) ||
+_reactive-graph__client__plugins__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client plugins uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances_commands] )) ||
+_reactive-graph__client__relation-instances_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client relation-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__add-component_commands] )) ||
+_reactive-graph__client__relation-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__add-property_commands] )) ||
+_reactive-graph__client__relation-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__create_commands] )) ||
+_reactive-graph__client__relation-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__delete_commands] )) ||
+_reactive-graph__client__relation-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__get_commands] )) ||
+_reactive-graph__client__relation-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__get-property_commands] )) ||
+_reactive-graph__client__relation-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help_commands] )) ||
+_reactive-graph__client__relation-instances__help_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client relation-instances help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__add-component_commands] )) ||
+_reactive-graph__client__relation-instances__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__add-property_commands] )) ||
+_reactive-graph__client__relation-instances__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__create_commands] )) ||
+_reactive-graph__client__relation-instances__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__delete_commands] )) ||
+_reactive-graph__client__relation-instances__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__get_commands] )) ||
+_reactive-graph__client__relation-instances__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__get-property_commands] )) ||
+_reactive-graph__client__relation-instances__help__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__help_commands] )) ||
+_reactive-graph__client__relation-instances__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__list_commands] )) ||
+_reactive-graph__client__relation-instances__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__list-components_commands] )) ||
+_reactive-graph__client__relation-instances__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__list-properties_commands] )) ||
+_reactive-graph__client__relation-instances__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__remove-component_commands] )) ||
+_reactive-graph__client__relation-instances__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__remove-property_commands] )) ||
+_reactive-graph__client__relation-instances__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__help__set-property_commands] )) ||
+_reactive-graph__client__relation-instances__help__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances help set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__list_commands] )) ||
+_reactive-graph__client__relation-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__list-components_commands] )) ||
+_reactive-graph__client__relation-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__list-properties_commands] )) ||
+_reactive-graph__client__relation-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__remove-component_commands] )) ||
+_reactive-graph__client__relation-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__remove-property_commands] )) ||
+_reactive-graph__client__relation-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-instances__set-property_commands] )) ||
+_reactive-graph__client__relation-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types_commands] )) ||
+_reactive-graph__client__relation-types_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client relation-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__add-component_commands] )) ||
+_reactive-graph__client__relation-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__add-extension_commands] )) ||
+_reactive-graph__client__relation-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__add-property_commands] )) ||
+_reactive-graph__client__relation-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__create_commands] )) ||
+_reactive-graph__client__relation-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__delete_commands] )) ||
+_reactive-graph__client__relation-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__get_commands] )) ||
+_reactive-graph__client__relation-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help_commands] )) ||
+_reactive-graph__client__relation-types__help_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client relation-types help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__add-component_commands] )) ||
+_reactive-graph__client__relation-types__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__add-extension_commands] )) ||
+_reactive-graph__client__relation-types__help__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__add-property_commands] )) ||
+_reactive-graph__client__relation-types__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__create_commands] )) ||
+_reactive-graph__client__relation-types__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__delete_commands] )) ||
+_reactive-graph__client__relation-types__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__get_commands] )) ||
+_reactive-graph__client__relation-types__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__help_commands] )) ||
+_reactive-graph__client__relation-types__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__list_commands] )) ||
+_reactive-graph__client__relation-types__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__list-components_commands] )) ||
+_reactive-graph__client__relation-types__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__list-extensions_commands] )) ||
+_reactive-graph__client__relation-types__help__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__list-properties_commands] )) ||
+_reactive-graph__client__relation-types__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__remove-component_commands] )) ||
+_reactive-graph__client__relation-types__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__remove-extension_commands] )) ||
+_reactive-graph__client__relation-types__help__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__remove-property_commands] )) ||
+_reactive-graph__client__relation-types__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__help__update-description_commands] )) ||
+_reactive-graph__client__relation-types__help__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types help update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__list_commands] )) ||
+_reactive-graph__client__relation-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__list-components_commands] )) ||
+_reactive-graph__client__relation-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__list-extensions_commands] )) ||
+_reactive-graph__client__relation-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__list-properties_commands] )) ||
+_reactive-graph__client__relation-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__remove-component_commands] )) ||
+_reactive-graph__client__relation-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__remove-extension_commands] )) ||
+_reactive-graph__client__relation-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__remove-property_commands] )) ||
+_reactive-graph__client__relation-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__relation-types__update-description_commands] )) ||
+_reactive-graph__client__relation-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client relation-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes_commands] )) ||
+_reactive-graph__client__remotes_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__add_commands] )) ||
+_reactive-graph__client__remotes__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes add commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph__client__remotes__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph__client__remotes__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help_commands] )) ||
+_reactive-graph__client__remotes__help_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph client remotes help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__add_commands] )) ||
+_reactive-graph__client__remotes__help__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help add commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph__client__remotes__help__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph__client__remotes__help__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__help_commands] )) ||
+_reactive-graph__client__remotes__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__list_commands] )) ||
+_reactive-graph__client__remotes__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__remove_commands] )) ||
+_reactive-graph__client__remotes__help__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__remove-all_commands] )) ||
+_reactive-graph__client__remotes__help__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__update_commands] )) ||
+_reactive-graph__client__remotes__help__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help update commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__help__update-all_commands] )) ||
+_reactive-graph__client__remotes__help__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes help update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__list_commands] )) ||
+_reactive-graph__client__remotes__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__remove_commands] )) ||
+_reactive-graph__client__remotes__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__remove-all_commands] )) ||
+_reactive-graph__client__remotes__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__update_commands] )) ||
+_reactive-graph__client__remotes__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes update commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__remotes__update-all_commands] )) ||
+_reactive-graph__client__remotes__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client remotes update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__client__shutdown_commands] )) ||
+_reactive-graph__client__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph client shutdown commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help_commands] )) ||
+_reactive-graph__help_commands() {
+    local commands; commands=(
+'client:Connects to a client' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client_commands] )) ||
+_reactive-graph__help__client_commands() {
+    local commands; commands=(
+'execute-command:Executes a command on the client' \
+'instance-info:Prints information about the instance' \
+'plugins:Manage plugins' \
+'remotes:Manage remotes' \
+'shutdown:Shutdown the runtime' \
+'components:Manage components' \
+'entity-types:Manage entity types' \
+'relation-types:Manage entity types' \
+'entity-instances:Manage entity instances' \
+'relation-instances:Manage relation instances' \
+    )
+    _describe -t commands 'reactive-graph help client commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components_commands] )) ||
+_reactive-graph__help__client__components_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+    )
+    _describe -t commands 'reactive-graph help client components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__add-extension_commands] )) ||
+_reactive-graph__help__client__components__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__add-property_commands] )) ||
+_reactive-graph__help__client__components__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__create_commands] )) ||
+_reactive-graph__help__client__components__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__delete_commands] )) ||
+_reactive-graph__help__client__components__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__get_commands] )) ||
+_reactive-graph__help__client__components__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__list_commands] )) ||
+_reactive-graph__help__client__components__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__list-extensions_commands] )) ||
+_reactive-graph__help__client__components__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__list-properties_commands] )) ||
+_reactive-graph__help__client__components__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__remove-extension_commands] )) ||
+_reactive-graph__help__client__components__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__remove-property_commands] )) ||
+_reactive-graph__help__client__components__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__components__update-description_commands] )) ||
+_reactive-graph__help__client__components__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client components update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances_commands] )) ||
+_reactive-graph__help__client__entity-instances_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+    )
+    _describe -t commands 'reactive-graph help client entity-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__add-component_commands] )) ||
+_reactive-graph__help__client__entity-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__add-property_commands] )) ||
+_reactive-graph__help__client__entity-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__create_commands] )) ||
+_reactive-graph__help__client__entity-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__delete_commands] )) ||
+_reactive-graph__help__client__entity-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__get_commands] )) ||
+_reactive-graph__help__client__entity-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__get-by-label_commands] )) ||
+_reactive-graph__help__client__entity-instances__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__get-property_commands] )) ||
+_reactive-graph__help__client__entity-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__list_commands] )) ||
+_reactive-graph__help__client__entity-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__list-components_commands] )) ||
+_reactive-graph__help__client__entity-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__list-properties_commands] )) ||
+_reactive-graph__help__client__entity-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__remove-component_commands] )) ||
+_reactive-graph__help__client__entity-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__remove-property_commands] )) ||
+_reactive-graph__help__client__entity-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-instances__set-property_commands] )) ||
+_reactive-graph__help__client__entity-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types_commands] )) ||
+_reactive-graph__help__client__entity-types_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+    )
+    _describe -t commands 'reactive-graph help client entity-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__add-component_commands] )) ||
+_reactive-graph__help__client__entity-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__add-extension_commands] )) ||
+_reactive-graph__help__client__entity-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__add-property_commands] )) ||
+_reactive-graph__help__client__entity-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__create_commands] )) ||
+_reactive-graph__help__client__entity-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__delete_commands] )) ||
+_reactive-graph__help__client__entity-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__get_commands] )) ||
+_reactive-graph__help__client__entity-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__list_commands] )) ||
+_reactive-graph__help__client__entity-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__list-components_commands] )) ||
+_reactive-graph__help__client__entity-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__list-extensions_commands] )) ||
+_reactive-graph__help__client__entity-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__list-properties_commands] )) ||
+_reactive-graph__help__client__entity-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__remove-component_commands] )) ||
+_reactive-graph__help__client__entity-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__remove-extension_commands] )) ||
+_reactive-graph__help__client__entity-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__remove-property_commands] )) ||
+_reactive-graph__help__client__entity-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__entity-types__update-description_commands] )) ||
+_reactive-graph__help__client__entity-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client entity-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__execute-command_commands] )) ||
+_reactive-graph__help__client__execute-command_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client execute-command commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__instance-info_commands] )) ||
+_reactive-graph__help__client__instance-info_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+    )
+    _describe -t commands 'reactive-graph help client instance-info commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__instance-info__get_commands] )) ||
+_reactive-graph__help__client__instance-info__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client instance-info get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins_commands] )) ||
+_reactive-graph__help__client__plugins_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+    )
+    _describe -t commands 'reactive-graph help client plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__dependencies_commands] )) ||
+_reactive-graph__help__client__plugins__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__dependents_commands] )) ||
+_reactive-graph__help__client__plugins__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__get_commands] )) ||
+_reactive-graph__help__client__plugins__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__list_commands] )) ||
+_reactive-graph__help__client__plugins__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__restart_commands] )) ||
+_reactive-graph__help__client__plugins__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__search_commands] )) ||
+_reactive-graph__help__client__plugins__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins search commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__start_commands] )) ||
+_reactive-graph__help__client__plugins__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins start commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__stop_commands] )) ||
+_reactive-graph__help__client__plugins__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__plugins__uninstall_commands] )) ||
+_reactive-graph__help__client__plugins__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client plugins uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances_commands] )) ||
+_reactive-graph__help__client__relation-instances_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+    )
+    _describe -t commands 'reactive-graph help client relation-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__add-component_commands] )) ||
+_reactive-graph__help__client__relation-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__add-property_commands] )) ||
+_reactive-graph__help__client__relation-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__create_commands] )) ||
+_reactive-graph__help__client__relation-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__delete_commands] )) ||
+_reactive-graph__help__client__relation-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__get_commands] )) ||
+_reactive-graph__help__client__relation-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__get-property_commands] )) ||
+_reactive-graph__help__client__relation-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__list_commands] )) ||
+_reactive-graph__help__client__relation-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__list-components_commands] )) ||
+_reactive-graph__help__client__relation-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__list-properties_commands] )) ||
+_reactive-graph__help__client__relation-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__remove-component_commands] )) ||
+_reactive-graph__help__client__relation-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__remove-property_commands] )) ||
+_reactive-graph__help__client__relation-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-instances__set-property_commands] )) ||
+_reactive-graph__help__client__relation-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types_commands] )) ||
+_reactive-graph__help__client__relation-types_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+    )
+    _describe -t commands 'reactive-graph help client relation-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__add-component_commands] )) ||
+_reactive-graph__help__client__relation-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__add-extension_commands] )) ||
+_reactive-graph__help__client__relation-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__add-property_commands] )) ||
+_reactive-graph__help__client__relation-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__create_commands] )) ||
+_reactive-graph__help__client__relation-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__delete_commands] )) ||
+_reactive-graph__help__client__relation-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__get_commands] )) ||
+_reactive-graph__help__client__relation-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__list_commands] )) ||
+_reactive-graph__help__client__relation-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__list-components_commands] )) ||
+_reactive-graph__help__client__relation-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__list-extensions_commands] )) ||
+_reactive-graph__help__client__relation-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__list-properties_commands] )) ||
+_reactive-graph__help__client__relation-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__remove-component_commands] )) ||
+_reactive-graph__help__client__relation-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__remove-extension_commands] )) ||
+_reactive-graph__help__client__relation-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__remove-property_commands] )) ||
+_reactive-graph__help__client__relation-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__relation-types__update-description_commands] )) ||
+_reactive-graph__help__client__relation-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client relation-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes_commands] )) ||
+_reactive-graph__help__client__remotes_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+    )
+    _describe -t commands 'reactive-graph help client remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__add_commands] )) ||
+_reactive-graph__help__client__remotes__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes add commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph__help__client__remotes__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph__help__client__remotes__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__list_commands] )) ||
+_reactive-graph__help__client__remotes__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes list commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__remove_commands] )) ||
+_reactive-graph__help__client__remotes__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__remove-all_commands] )) ||
+_reactive-graph__help__client__remotes__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__update_commands] )) ||
+_reactive-graph__help__client__remotes__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes update commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__remotes__update-all_commands] )) ||
+_reactive-graph__help__client__remotes__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client remotes update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__client__shutdown_commands] )) ||
+_reactive-graph__help__client__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help client shutdown commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__help_commands] )) ||
+_reactive-graph__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help help commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_reactive-graph" ]; then
+    _reactive-graph "$@"
+else
+    compdef _reactive-graph reactive-graph
+fi

--- a/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-client
+++ b/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-client
@@ -1,0 +1,3831 @@
+#compdef reactive-graph-client
+
+autoload -U is-at-least
+
+_reactive-graph-client() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname to connect to]:HOSTNAME: ' \
+'--port=[The port to connect to]:PORT: ' \
+'--secure=[If true, connects via HTTPS]:SECURE:(true false)' \
+'--endpoint-graphql=[The endpoint to use]:ENDPOINT_GRAPHQL: ' \
+'--endpoint-dynamic-graph=[The endpoint to use]:ENDPOINT_DYNAMIC_GRAPH: ' \
+'--endpoint-runtime=[The endpoint to use]:ENDPOINT_RUNTIME: ' \
+'--endpoint-plugins=[The endpoint to use]:ENDPOINT_PLUGINS: ' \
+'--bearer=[The authentication token]:BEARER: ' \
+'--print-shell-completions=[If true, prints shell completions]:PRINT_SHELL_COMPLETIONS:(bash elvish fish powershell zsh)' \
+'--install-shell-completions=[If true, installs shell completions]:INSTALL_SHELL_COMPLETIONS:(bash elvish fish powershell zsh)' \
+'--markdown-help[If true, generates command line documentation]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph-client_commands" \
+"*::: :->reactive-graph-client" \
+&& ret=0
+    case $state in
+    (reactive-graph-client)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-command-$line[1]:"
+        case $line[1] in
+            (execute-command)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':command_name -- The command name:' \
+'*::command_arguments -- The command arguments:' \
+&& ret=0
+;;
+(instance-info)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__instance-info_commands" \
+"*::: :->instance-info" \
+&& ret=0
+
+    case $state in
+    (instance-info)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-instance-info-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__instance-info__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-instance-info-help-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(plugins)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__plugins_commands" \
+"*::: :->plugins" \
+&& ret=0
+
+    case $state in
+    (plugins)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-plugins-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+'--name=[The plugin name]:NAME: ' \
+'--state=[The plugin state]:STATE: ' \
+'--stem=[The plugin file stem]:STEM: ' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+':name -- The plugin name:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__plugins__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-plugins-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(remotes)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__remotes_commands" \
+"*::: :->remotes" \
+&& ret=0
+
+    case $state in
+    (remotes)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-remotes-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+'--hostname=[The hostname]:HOSTNAME: ' \
+'--port=[The port]:PORT: ' \
+'--secure=[The protocol]:SECURE:(true false)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__remotes__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-remotes-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__components_commands" \
+"*::: :->components" \
+&& ret=0
+
+    case $state in
+    (components)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-components-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+'::description -- The component description:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+':description -- Textual description of the extension:' \
+':extension -- The extension as JSON representation:' \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+':description -- The description to update:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__components__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-components-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(entity-types)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__entity-types_commands" \
+"*::: :->entity-types" \
+&& ret=0
+
+    case $state in
+    (entity-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+'::description -- The entity type description:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+':description -- Textual description of the extension:' \
+':extension -- The extension as JSON representation:' \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+':description -- The description to update:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__entity-types__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-types-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(relation-types)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__relation-types_commands" \
+"*::: :->relation-types" \
+&& ret=0
+
+    case $state in
+    (relation-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':outbound_type_namespace -- The outbound entity type namespace:' \
+':outbound_type_name -- The outbound entity type name:' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':inbound_type_namespace -- The inbound entity type namespace:' \
+':inbound_type_name -- The inbound entity type name:' \
+'::description -- The relation type description:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+':description -- Textual description of the extension:' \
+':extension -- The extension as JSON representation:' \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':extension_namespace -- The extension namespace:' \
+':extension_name -- The extension name:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':description -- The description to update:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__relation-types__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-types-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(entity-instances)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__entity-instances_commands" \
+"*::: :->entity-instances" \
+&& ret=0
+
+    case $state in
+    (entity-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'--namespace=[The entity type namespace]:NAMESPACE: ' \
+'-n+[The entity type name]:NAME: ' \
+'--name=[The entity type name]:NAME: ' \
+'-i+[The id of the entity instance]:ID: ' \
+'--id=[The id of the entity instance]:ID: ' \
+'-l+[The label of the entity instance]:LABEL: ' \
+'--label=[The label of the entity instance]:LABEL: ' \
+'*-p+[The properties to search for]:PROPERTIES: ' \
+'*--properties=[The properties to search for]:PROPERTIES: ' \
+'*-c+[The components to search for]:COMPONENTS: ' \
+'*--components=[The components to search for]:COMPONENTS: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':label -- The label of the reactive instance:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the entity instance:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':id -- The id of the reactive instance:' \
+':name -- The name of the property:' \
+':value -- The new JSON value of the property:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the reactive instance:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the entity instance:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the reactive instance:' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the reactive instance:' \
+':namespace -- The component namespace:' \
+':name -- The component name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'-i+[The entity instance id]:ID: ' \
+'--id=[The entity instance id]:ID: ' \
+'-d+[The entity instance description]:DESCRIPTION: ' \
+'--description=[The entity instance description]:DESCRIPTION: ' \
+'*-p+[The entity instance properties]:PROPERTIES: ' \
+'*--properties=[The entity instance properties]:PROPERTIES: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The entity type namespace:' \
+':name -- The entity type name:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':id -- The id of the entity instance:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__entity-instances__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-entity-instances-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(relation-instances)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_reactive-graph-client__relation-instances_commands" \
+"*::: :->relation-instances" \
+&& ret=0
+
+    case $state in
+    (relation-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'--namespace=[The relation type namespace]:NAMESPACE: ' \
+'-n+[The relation type name]:NAME: ' \
+'--name=[The relation type name]:NAME: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'*-p+[The properties to search for]:PROPERTIES: ' \
+'*--properties=[The properties to search for]:PROPERTIES: ' \
+'*-c+[The components to search for]:COMPONENTS: ' \
+'*--components=[The components to search for]:COMPONENTS: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+':property_value -- The JSON value of the property:' \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+':data_type -- The data type of the property:' \
+':socket_type -- The socket type of the property:' \
+':mutability -- If the property is mutable or not:' \
+'::description -- Description of the property:' \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':property_name -- The name of the property:' \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+':component_namespace -- The component namespace:' \
+':component_name -- The component name:' \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-d+[The relation instance description]:DESCRIPTION: ' \
+'--description=[The relation instance description]:DESCRIPTION: ' \
+'*-p+[The relation instance properties]:PROPERTIES: ' \
+'*--properties=[The relation instance properties]:PROPERTIES: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+'--outbound-id=[The id of the outbound entity instance]:OUTBOUND_ID: ' \
+'-i+[The id of the inbound entity instance]:INBOUND_ID: ' \
+'--inbound-id=[The id of the inbound entity instance]:INBOUND_ID: ' \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+':namespace -- The relation type namespace:' \
+':name -- The relation type name:' \
+':instance_id -- The instance id:' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__relation-instances__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-relation-instances-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-command-$line[1]:"
+        case $line[1] in
+            (execute-command)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(instance-info)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__instance-info_commands" \
+"*::: :->instance-info" \
+&& ret=0
+
+    case $state in
+    (instance-info)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-instance-info-command-$line[1]:"
+        case $line[1] in
+            (get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(plugins)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__plugins_commands" \
+"*::: :->plugins" \
+&& ret=0
+
+    case $state in
+    (plugins)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-plugins-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(search)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependencies)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dependents)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(start)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(stop)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(restart)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(uninstall)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(remotes)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__remotes_commands" \
+"*::: :->remotes" \
+&& ret=0
+
+    case $state in
+    (remotes)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-remotes-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-all)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-remote)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(fetch-remotes-from-all-remotes)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(shutdown)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(components)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__components_commands" \
+"*::: :->components" \
+&& ret=0
+
+    case $state in
+    (components)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-components-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(entity-types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__entity-types_commands" \
+"*::: :->entity-types" \
+&& ret=0
+
+    case $state in
+    (entity-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-entity-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(relation-types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__relation-types_commands" \
+"*::: :->relation-types" \
+&& ret=0
+
+    case $state in
+    (relation-types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-relation-types-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-extension)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(update-description)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(entity-instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__entity-instances_commands" \
+"*::: :->entity-instances" \
+&& ret=0
+
+    case $state in
+    (entity-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-entity-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-by-label)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(relation-instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__relation-instances_commands" \
+"*::: :->relation-instances" \
+&& ret=0
+
+    case $state in
+    (relation-instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-relation-instances-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-properties)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(set-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-property)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(add-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(remove-component)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(create)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(delete)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_reactive-graph-client_commands] )) ||
+_reactive-graph-client_commands() {
+    local commands; commands=(
+'execute-command:Executes a command on the client' \
+'instance-info:Prints information about the instance' \
+'plugins:Manage plugins' \
+'remotes:Manage remotes' \
+'shutdown:Shutdown the runtime' \
+'components:Manage components' \
+'entity-types:Manage entity types' \
+'relation-types:Manage entity types' \
+'entity-instances:Manage entity instances' \
+'relation-instances:Manage relation instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components_commands] )) ||
+_reactive-graph-client__components_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__add-extension_commands] )) ||
+_reactive-graph-client__components__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__add-property_commands] )) ||
+_reactive-graph-client__components__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__create_commands] )) ||
+_reactive-graph-client__components__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__delete_commands] )) ||
+_reactive-graph-client__components__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__get_commands] )) ||
+_reactive-graph-client__components__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help_commands] )) ||
+_reactive-graph-client__components__help_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client components help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__add-extension_commands] )) ||
+_reactive-graph-client__components__help__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__add-property_commands] )) ||
+_reactive-graph-client__components__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__create_commands] )) ||
+_reactive-graph-client__components__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__delete_commands] )) ||
+_reactive-graph-client__components__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__get_commands] )) ||
+_reactive-graph-client__components__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__help_commands] )) ||
+_reactive-graph-client__components__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__list_commands] )) ||
+_reactive-graph-client__components__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__list-extensions_commands] )) ||
+_reactive-graph-client__components__help__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__list-properties_commands] )) ||
+_reactive-graph-client__components__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__remove-extension_commands] )) ||
+_reactive-graph-client__components__help__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__remove-property_commands] )) ||
+_reactive-graph-client__components__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__update-description_commands] )) ||
+_reactive-graph-client__components__help__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__list_commands] )) ||
+_reactive-graph-client__components__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__list-extensions_commands] )) ||
+_reactive-graph-client__components__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__list-properties_commands] )) ||
+_reactive-graph-client__components__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__remove-extension_commands] )) ||
+_reactive-graph-client__components__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__remove-property_commands] )) ||
+_reactive-graph-client__components__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__update-description_commands] )) ||
+_reactive-graph-client__components__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances_commands] )) ||
+_reactive-graph-client__entity-instances_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client entity-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__add-component_commands] )) ||
+_reactive-graph-client__entity-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__add-property_commands] )) ||
+_reactive-graph-client__entity-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__create_commands] )) ||
+_reactive-graph-client__entity-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__delete_commands] )) ||
+_reactive-graph-client__entity-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__get_commands] )) ||
+_reactive-graph-client__entity-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__get-by-label_commands] )) ||
+_reactive-graph-client__entity-instances__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__get-property_commands] )) ||
+_reactive-graph-client__entity-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help_commands] )) ||
+_reactive-graph-client__entity-instances__help_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client entity-instances help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__add-component_commands] )) ||
+_reactive-graph-client__entity-instances__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__add-property_commands] )) ||
+_reactive-graph-client__entity-instances__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__create_commands] )) ||
+_reactive-graph-client__entity-instances__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__delete_commands] )) ||
+_reactive-graph-client__entity-instances__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__get_commands] )) ||
+_reactive-graph-client__entity-instances__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__get-by-label_commands] )) ||
+_reactive-graph-client__entity-instances__help__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__get-property_commands] )) ||
+_reactive-graph-client__entity-instances__help__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__help_commands] )) ||
+_reactive-graph-client__entity-instances__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__list_commands] )) ||
+_reactive-graph-client__entity-instances__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__list-components_commands] )) ||
+_reactive-graph-client__entity-instances__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__list-properties_commands] )) ||
+_reactive-graph-client__entity-instances__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__remove-component_commands] )) ||
+_reactive-graph-client__entity-instances__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__remove-property_commands] )) ||
+_reactive-graph-client__entity-instances__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__help__set-property_commands] )) ||
+_reactive-graph-client__entity-instances__help__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances help set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__list_commands] )) ||
+_reactive-graph-client__entity-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__list-components_commands] )) ||
+_reactive-graph-client__entity-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__list-properties_commands] )) ||
+_reactive-graph-client__entity-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__remove-component_commands] )) ||
+_reactive-graph-client__entity-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__remove-property_commands] )) ||
+_reactive-graph-client__entity-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-instances__set-property_commands] )) ||
+_reactive-graph-client__entity-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types_commands] )) ||
+_reactive-graph-client__entity-types_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client entity-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__add-component_commands] )) ||
+_reactive-graph-client__entity-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__add-extension_commands] )) ||
+_reactive-graph-client__entity-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__add-property_commands] )) ||
+_reactive-graph-client__entity-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__create_commands] )) ||
+_reactive-graph-client__entity-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__delete_commands] )) ||
+_reactive-graph-client__entity-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__get_commands] )) ||
+_reactive-graph-client__entity-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help_commands] )) ||
+_reactive-graph-client__entity-types__help_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client entity-types help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__add-component_commands] )) ||
+_reactive-graph-client__entity-types__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__add-extension_commands] )) ||
+_reactive-graph-client__entity-types__help__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__add-property_commands] )) ||
+_reactive-graph-client__entity-types__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__create_commands] )) ||
+_reactive-graph-client__entity-types__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__delete_commands] )) ||
+_reactive-graph-client__entity-types__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__get_commands] )) ||
+_reactive-graph-client__entity-types__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__help_commands] )) ||
+_reactive-graph-client__entity-types__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__list_commands] )) ||
+_reactive-graph-client__entity-types__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__list-components_commands] )) ||
+_reactive-graph-client__entity-types__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__list-extensions_commands] )) ||
+_reactive-graph-client__entity-types__help__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__list-properties_commands] )) ||
+_reactive-graph-client__entity-types__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__remove-component_commands] )) ||
+_reactive-graph-client__entity-types__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__remove-extension_commands] )) ||
+_reactive-graph-client__entity-types__help__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__remove-property_commands] )) ||
+_reactive-graph-client__entity-types__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__update-description_commands] )) ||
+_reactive-graph-client__entity-types__help__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__list_commands] )) ||
+_reactive-graph-client__entity-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__list-components_commands] )) ||
+_reactive-graph-client__entity-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__list-extensions_commands] )) ||
+_reactive-graph-client__entity-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__list-properties_commands] )) ||
+_reactive-graph-client__entity-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__remove-component_commands] )) ||
+_reactive-graph-client__entity-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__remove-extension_commands] )) ||
+_reactive-graph-client__entity-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__remove-property_commands] )) ||
+_reactive-graph-client__entity-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__update-description_commands] )) ||
+_reactive-graph-client__entity-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__execute-command_commands] )) ||
+_reactive-graph-client__execute-command_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client execute-command commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help_commands] )) ||
+_reactive-graph-client__help_commands() {
+    local commands; commands=(
+'execute-command:Executes a command on the client' \
+'instance-info:Prints information about the instance' \
+'plugins:Manage plugins' \
+'remotes:Manage remotes' \
+'shutdown:Shutdown the runtime' \
+'components:Manage components' \
+'entity-types:Manage entity types' \
+'relation-types:Manage entity types' \
+'entity-instances:Manage entity instances' \
+'relation-instances:Manage relation instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components_commands] )) ||
+_reactive-graph-client__help__components_commands() {
+    local commands; commands=(
+'list:List all components' \
+'get:Prints a single component' \
+'list-properties:List the properties of a component' \
+'list-extensions:List the extensions of a component' \
+'create:Creates a new component' \
+'delete:Deletes a component' \
+'add-property:Adds a property to a component' \
+'remove-property:Removes a property from a component' \
+'add-extension:Adds an extension to a component' \
+'remove-extension:Removes an extension from a component' \
+'update-description:Updates the description of a component' \
+    )
+    _describe -t commands 'reactive-graph-client help components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__add-extension_commands] )) ||
+_reactive-graph-client__help__components__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__add-property_commands] )) ||
+_reactive-graph-client__help__components__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__create_commands] )) ||
+_reactive-graph-client__help__components__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__delete_commands] )) ||
+_reactive-graph-client__help__components__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__get_commands] )) ||
+_reactive-graph-client__help__components__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__list_commands] )) ||
+_reactive-graph-client__help__components__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__list-extensions_commands] )) ||
+_reactive-graph-client__help__components__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__list-properties_commands] )) ||
+_reactive-graph-client__help__components__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__remove-extension_commands] )) ||
+_reactive-graph-client__help__components__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__remove-property_commands] )) ||
+_reactive-graph-client__help__components__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__update-description_commands] )) ||
+_reactive-graph-client__help__components__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances_commands] )) ||
+_reactive-graph-client__help__entity-instances_commands() {
+    local commands; commands=(
+'list:List all entity instances' \
+'get:Prints a single entity instance' \
+'get-by-label:Prints a single entity instance' \
+'list-properties:Lists the properties of an entity instance' \
+'get-property:Prints the value of a property of an entity instance' \
+'set-property:Sets the value of a property of an entity instance' \
+'add-property:Adds a new property to an entity instance' \
+'remove-property:Removes a property from an entity instance' \
+'list-components:Lists the components of an entity instance' \
+'add-component:Adds a component to an entity instance' \
+'remove-component:Removes a component from an entity instance' \
+'create:Creates a new entity type' \
+'delete:CLI argument which identifies an entity instance by its id' \
+    )
+    _describe -t commands 'reactive-graph-client help entity-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__add-component_commands] )) ||
+_reactive-graph-client__help__entity-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__add-property_commands] )) ||
+_reactive-graph-client__help__entity-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__create_commands] )) ||
+_reactive-graph-client__help__entity-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__delete_commands] )) ||
+_reactive-graph-client__help__entity-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__get_commands] )) ||
+_reactive-graph-client__help__entity-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__get-by-label_commands] )) ||
+_reactive-graph-client__help__entity-instances__get-by-label_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances get-by-label commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__get-property_commands] )) ||
+_reactive-graph-client__help__entity-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__list_commands] )) ||
+_reactive-graph-client__help__entity-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__list-components_commands] )) ||
+_reactive-graph-client__help__entity-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__list-properties_commands] )) ||
+_reactive-graph-client__help__entity-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__remove-component_commands] )) ||
+_reactive-graph-client__help__entity-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__remove-property_commands] )) ||
+_reactive-graph-client__help__entity-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-instances__set-property_commands] )) ||
+_reactive-graph-client__help__entity-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types_commands] )) ||
+_reactive-graph-client__help__entity-types_commands() {
+    local commands; commands=(
+'list:List all entity types' \
+'get:Prints a single entity type' \
+'list-properties:List the properties of an entity type' \
+'list-extensions:List the extensions of an entity type' \
+'list-components:List the components of an entity type' \
+'create:Creates a new entity type' \
+'delete:Deletes a entity type' \
+'add-property:Adds a property to an entity type' \
+'remove-property:Removes a property from an entity type' \
+'add-extension:Adds an extension to an entity type' \
+'remove-extension:Removes an extension from an entity type' \
+'add-component:Adds a component to an entity type' \
+'remove-component:Removes a component from an entity type' \
+'update-description:Updates the description of an entity type' \
+    )
+    _describe -t commands 'reactive-graph-client help entity-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__add-component_commands] )) ||
+_reactive-graph-client__help__entity-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__add-extension_commands] )) ||
+_reactive-graph-client__help__entity-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__add-property_commands] )) ||
+_reactive-graph-client__help__entity-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__create_commands] )) ||
+_reactive-graph-client__help__entity-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__delete_commands] )) ||
+_reactive-graph-client__help__entity-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__get_commands] )) ||
+_reactive-graph-client__help__entity-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__list_commands] )) ||
+_reactive-graph-client__help__entity-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__list-components_commands] )) ||
+_reactive-graph-client__help__entity-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__list-extensions_commands] )) ||
+_reactive-graph-client__help__entity-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__list-properties_commands] )) ||
+_reactive-graph-client__help__entity-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__remove-component_commands] )) ||
+_reactive-graph-client__help__entity-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__remove-extension_commands] )) ||
+_reactive-graph-client__help__entity-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__remove-property_commands] )) ||
+_reactive-graph-client__help__entity-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__update-description_commands] )) ||
+_reactive-graph-client__help__entity-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__execute-command_commands] )) ||
+_reactive-graph-client__help__execute-command_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help execute-command commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__help_commands] )) ||
+_reactive-graph-client__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__instance-info_commands] )) ||
+_reactive-graph-client__help__instance-info_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+    )
+    _describe -t commands 'reactive-graph-client help instance-info commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__instance-info__get_commands] )) ||
+_reactive-graph-client__help__instance-info__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help instance-info get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins_commands] )) ||
+_reactive-graph-client__help__plugins_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+    )
+    _describe -t commands 'reactive-graph-client help plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__dependencies_commands] )) ||
+_reactive-graph-client__help__plugins__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__dependents_commands] )) ||
+_reactive-graph-client__help__plugins__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__get_commands] )) ||
+_reactive-graph-client__help__plugins__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__list_commands] )) ||
+_reactive-graph-client__help__plugins__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__restart_commands] )) ||
+_reactive-graph-client__help__plugins__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__search_commands] )) ||
+_reactive-graph-client__help__plugins__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins search commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__start_commands] )) ||
+_reactive-graph-client__help__plugins__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins start commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__stop_commands] )) ||
+_reactive-graph-client__help__plugins__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__plugins__uninstall_commands] )) ||
+_reactive-graph-client__help__plugins__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help plugins uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances_commands] )) ||
+_reactive-graph-client__help__relation-instances_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+    )
+    _describe -t commands 'reactive-graph-client help relation-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__add-component_commands] )) ||
+_reactive-graph-client__help__relation-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__add-property_commands] )) ||
+_reactive-graph-client__help__relation-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__create_commands] )) ||
+_reactive-graph-client__help__relation-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__delete_commands] )) ||
+_reactive-graph-client__help__relation-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__get_commands] )) ||
+_reactive-graph-client__help__relation-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__get-property_commands] )) ||
+_reactive-graph-client__help__relation-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__list_commands] )) ||
+_reactive-graph-client__help__relation-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__list-components_commands] )) ||
+_reactive-graph-client__help__relation-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__list-properties_commands] )) ||
+_reactive-graph-client__help__relation-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__remove-component_commands] )) ||
+_reactive-graph-client__help__relation-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__remove-property_commands] )) ||
+_reactive-graph-client__help__relation-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-instances__set-property_commands] )) ||
+_reactive-graph-client__help__relation-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types_commands] )) ||
+_reactive-graph-client__help__relation-types_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+    )
+    _describe -t commands 'reactive-graph-client help relation-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__add-component_commands] )) ||
+_reactive-graph-client__help__relation-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__add-extension_commands] )) ||
+_reactive-graph-client__help__relation-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__add-property_commands] )) ||
+_reactive-graph-client__help__relation-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__create_commands] )) ||
+_reactive-graph-client__help__relation-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__delete_commands] )) ||
+_reactive-graph-client__help__relation-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__get_commands] )) ||
+_reactive-graph-client__help__relation-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__list_commands] )) ||
+_reactive-graph-client__help__relation-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__list-components_commands] )) ||
+_reactive-graph-client__help__relation-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__list-extensions_commands] )) ||
+_reactive-graph-client__help__relation-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__list-properties_commands] )) ||
+_reactive-graph-client__help__relation-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__remove-component_commands] )) ||
+_reactive-graph-client__help__relation-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__remove-extension_commands] )) ||
+_reactive-graph-client__help__relation-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__remove-property_commands] )) ||
+_reactive-graph-client__help__relation-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__update-description_commands] )) ||
+_reactive-graph-client__help__relation-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes_commands] )) ||
+_reactive-graph-client__help__remotes_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+    )
+    _describe -t commands 'reactive-graph-client help remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__add_commands] )) ||
+_reactive-graph-client__help__remotes__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes add commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph-client__help__remotes__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph-client__help__remotes__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__list_commands] )) ||
+_reactive-graph-client__help__remotes__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__remove_commands] )) ||
+_reactive-graph-client__help__remotes__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__remove-all_commands] )) ||
+_reactive-graph-client__help__remotes__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__update_commands] )) ||
+_reactive-graph-client__help__remotes__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes update commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__remotes__update-all_commands] )) ||
+_reactive-graph-client__help__remotes__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help remotes update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__shutdown_commands] )) ||
+_reactive-graph-client__help__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help shutdown commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__instance-info_commands] )) ||
+_reactive-graph-client__instance-info_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client instance-info commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__instance-info__get_commands] )) ||
+_reactive-graph-client__instance-info__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client instance-info get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__instance-info__help_commands] )) ||
+_reactive-graph-client__instance-info__help_commands() {
+    local commands; commands=(
+'get:Get instance information' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client instance-info help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__instance-info__help__get_commands] )) ||
+_reactive-graph-client__instance-info__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client instance-info help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__instance-info__help__help_commands] )) ||
+_reactive-graph-client__instance-info__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client instance-info help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins_commands] )) ||
+_reactive-graph-client__plugins_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__dependencies_commands] )) ||
+_reactive-graph-client__plugins__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__dependents_commands] )) ||
+_reactive-graph-client__plugins__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__get_commands] )) ||
+_reactive-graph-client__plugins__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help_commands] )) ||
+_reactive-graph-client__plugins__help_commands() {
+    local commands; commands=(
+'list:Lists all plugins' \
+'search:Search for plugins by name, state or stem' \
+'get:Prints a single plugin' \
+'dependencies:Depends on' \
+'dependents:Dependent plugins' \
+'start:Starts a plugin' \
+'stop:Stops a plugin' \
+'restart:Restarts a plugin' \
+'uninstall:Uninstall a plugin' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client plugins help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__dependencies_commands] )) ||
+_reactive-graph-client__plugins__help__dependencies_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help dependencies commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__dependents_commands] )) ||
+_reactive-graph-client__plugins__help__dependents_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help dependents commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__get_commands] )) ||
+_reactive-graph-client__plugins__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__help_commands] )) ||
+_reactive-graph-client__plugins__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__list_commands] )) ||
+_reactive-graph-client__plugins__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__restart_commands] )) ||
+_reactive-graph-client__plugins__help__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__search_commands] )) ||
+_reactive-graph-client__plugins__help__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help search commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__start_commands] )) ||
+_reactive-graph-client__plugins__help__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help start commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__stop_commands] )) ||
+_reactive-graph-client__plugins__help__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__help__uninstall_commands] )) ||
+_reactive-graph-client__plugins__help__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins help uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__list_commands] )) ||
+_reactive-graph-client__plugins__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__restart_commands] )) ||
+_reactive-graph-client__plugins__restart_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins restart commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__search_commands] )) ||
+_reactive-graph-client__plugins__search_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins search commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__start_commands] )) ||
+_reactive-graph-client__plugins__start_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins start commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__stop_commands] )) ||
+_reactive-graph-client__plugins__stop_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins stop commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__plugins__uninstall_commands] )) ||
+_reactive-graph-client__plugins__uninstall_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client plugins uninstall commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances_commands] )) ||
+_reactive-graph-client__relation-instances_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client relation-instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__add-component_commands] )) ||
+_reactive-graph-client__relation-instances__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__add-property_commands] )) ||
+_reactive-graph-client__relation-instances__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__create_commands] )) ||
+_reactive-graph-client__relation-instances__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__delete_commands] )) ||
+_reactive-graph-client__relation-instances__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__get_commands] )) ||
+_reactive-graph-client__relation-instances__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__get-property_commands] )) ||
+_reactive-graph-client__relation-instances__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help_commands] )) ||
+_reactive-graph-client__relation-instances__help_commands() {
+    local commands; commands=(
+'list:List all relation instances' \
+'get:Prints a single relation instance' \
+'list-properties:Lists the properties of a relation instance' \
+'get-property:Prints the value of a property of a relation instance' \
+'set-property:Sets the value of a property of a relation instance' \
+'add-property:Adds a new property to a relation instance' \
+'remove-property:Removes a property from a relation instance' \
+'list-components:Lists the components of a relation instance' \
+'add-component:Adds a component to a relation instance' \
+'remove-component:Removes a component from a relation instance' \
+'create:Creates a new relation type' \
+'delete:CLI argument which identifies an relation instance by its id' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client relation-instances help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__add-component_commands] )) ||
+_reactive-graph-client__relation-instances__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__add-property_commands] )) ||
+_reactive-graph-client__relation-instances__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__create_commands] )) ||
+_reactive-graph-client__relation-instances__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__delete_commands] )) ||
+_reactive-graph-client__relation-instances__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__get_commands] )) ||
+_reactive-graph-client__relation-instances__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__get-property_commands] )) ||
+_reactive-graph-client__relation-instances__help__get-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help get-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__help_commands] )) ||
+_reactive-graph-client__relation-instances__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__list_commands] )) ||
+_reactive-graph-client__relation-instances__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__list-components_commands] )) ||
+_reactive-graph-client__relation-instances__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__list-properties_commands] )) ||
+_reactive-graph-client__relation-instances__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__remove-component_commands] )) ||
+_reactive-graph-client__relation-instances__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__remove-property_commands] )) ||
+_reactive-graph-client__relation-instances__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__help__set-property_commands] )) ||
+_reactive-graph-client__relation-instances__help__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances help set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__list_commands] )) ||
+_reactive-graph-client__relation-instances__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__list-components_commands] )) ||
+_reactive-graph-client__relation-instances__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__list-properties_commands] )) ||
+_reactive-graph-client__relation-instances__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__remove-component_commands] )) ||
+_reactive-graph-client__relation-instances__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__remove-property_commands] )) ||
+_reactive-graph-client__relation-instances__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-instances__set-property_commands] )) ||
+_reactive-graph-client__relation-instances__set-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-instances set-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types_commands] )) ||
+_reactive-graph-client__relation-types_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client relation-types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__add-component_commands] )) ||
+_reactive-graph-client__relation-types__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__add-extension_commands] )) ||
+_reactive-graph-client__relation-types__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__add-property_commands] )) ||
+_reactive-graph-client__relation-types__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__create_commands] )) ||
+_reactive-graph-client__relation-types__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__delete_commands] )) ||
+_reactive-graph-client__relation-types__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__get_commands] )) ||
+_reactive-graph-client__relation-types__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help_commands] )) ||
+_reactive-graph-client__relation-types__help_commands() {
+    local commands; commands=(
+'list:List all relation types' \
+'get:Prints a single relation type' \
+'list-properties:List the properties of an relation type' \
+'list-extensions:List the extensions of an relation type' \
+'list-components:List the components of an relation type' \
+'create:Creates a new relation type' \
+'delete:Deletes a relation type' \
+'add-property:Adds a property to a relation type' \
+'remove-property:Removes a property from a relation type' \
+'add-extension:Adds an extension to a relation type' \
+'remove-extension:Removes an extension from a relation type' \
+'add-component:Adds a component to a relation type' \
+'remove-component:Removes a component from a relation type' \
+'update-description:Updates the description of a relation type' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client relation-types help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__add-component_commands] )) ||
+_reactive-graph-client__relation-types__help__add-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help add-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__add-extension_commands] )) ||
+_reactive-graph-client__relation-types__help__add-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help add-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__add-property_commands] )) ||
+_reactive-graph-client__relation-types__help__add-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help add-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__create_commands] )) ||
+_reactive-graph-client__relation-types__help__create_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help create commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__delete_commands] )) ||
+_reactive-graph-client__relation-types__help__delete_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help delete commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__get_commands] )) ||
+_reactive-graph-client__relation-types__help__get_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__help_commands] )) ||
+_reactive-graph-client__relation-types__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__list_commands] )) ||
+_reactive-graph-client__relation-types__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__list-components_commands] )) ||
+_reactive-graph-client__relation-types__help__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__list-extensions_commands] )) ||
+_reactive-graph-client__relation-types__help__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__list-properties_commands] )) ||
+_reactive-graph-client__relation-types__help__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__remove-component_commands] )) ||
+_reactive-graph-client__relation-types__help__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__remove-extension_commands] )) ||
+_reactive-graph-client__relation-types__help__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__remove-property_commands] )) ||
+_reactive-graph-client__relation-types__help__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__update-description_commands] )) ||
+_reactive-graph-client__relation-types__help__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__list_commands] )) ||
+_reactive-graph-client__relation-types__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__list-components_commands] )) ||
+_reactive-graph-client__relation-types__list-components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types list-components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__list-extensions_commands] )) ||
+_reactive-graph-client__relation-types__list-extensions_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types list-extensions commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__list-properties_commands] )) ||
+_reactive-graph-client__relation-types__list-properties_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types list-properties commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__remove-component_commands] )) ||
+_reactive-graph-client__relation-types__remove-component_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types remove-component commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__remove-extension_commands] )) ||
+_reactive-graph-client__relation-types__remove-extension_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types remove-extension commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__remove-property_commands] )) ||
+_reactive-graph-client__relation-types__remove-property_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types remove-property commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__update-description_commands] )) ||
+_reactive-graph-client__relation-types__update-description_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes_commands] )) ||
+_reactive-graph-client__remotes_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__add_commands] )) ||
+_reactive-graph-client__remotes__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes add commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph-client__remotes__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph-client__remotes__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help_commands] )) ||
+_reactive-graph-client__remotes__help_commands() {
+    local commands; commands=(
+'list:Lists the remotes' \
+'add:Adds a remote' \
+'remove:Removes a remote' \
+'remove-all:Removes all remotes' \
+'update:Updates a remote' \
+'update-all:Updates all remotes' \
+'fetch-remotes-from-remote:Fetches the remotes from the given remote' \
+'fetch-remotes-from-all-remotes:Fetches all remotes from all remotes' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client remotes help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__add_commands] )) ||
+_reactive-graph-client__remotes__help__add_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help add commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__fetch-remotes-from-all-remotes_commands] )) ||
+_reactive-graph-client__remotes__help__fetch-remotes-from-all-remotes_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help fetch-remotes-from-all-remotes commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__fetch-remotes-from-remote_commands] )) ||
+_reactive-graph-client__remotes__help__fetch-remotes-from-remote_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help fetch-remotes-from-remote commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__help_commands] )) ||
+_reactive-graph-client__remotes__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__list_commands] )) ||
+_reactive-graph-client__remotes__help__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__remove_commands] )) ||
+_reactive-graph-client__remotes__help__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__remove-all_commands] )) ||
+_reactive-graph-client__remotes__help__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__update_commands] )) ||
+_reactive-graph-client__remotes__help__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help update commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__help__update-all_commands] )) ||
+_reactive-graph-client__remotes__help__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes help update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__list_commands] )) ||
+_reactive-graph-client__remotes__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes list commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__remove_commands] )) ||
+_reactive-graph-client__remotes__remove_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__remove-all_commands] )) ||
+_reactive-graph-client__remotes__remove-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes remove-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__update_commands] )) ||
+_reactive-graph-client__remotes__update_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes update commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__remotes__update-all_commands] )) ||
+_reactive-graph-client__remotes__update-all_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client remotes update-all commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__shutdown_commands] )) ||
+_reactive-graph-client__shutdown_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client shutdown commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_reactive-graph-client" ]; then
+    _reactive-graph-client "$@"
+else
+    compdef _reactive-graph-client reactive-graph-client
+fi

--- a/crates/reactive-graph/src/cli/args.rs
+++ b/crates/reactive-graph/src/cli/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use clap_complete::Shell;
 
 use crate::cli::commands::ClientCommands;
 use reactive_graph_remotes_model::InstanceAddress;
@@ -47,6 +48,25 @@ pub struct ClientArgs {
     /// If true, generates command line documentation.
     #[arg(long, hide = true)]
     pub(crate) markdown_help: bool,
+
+    /// If true, generates man pages.
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    pub(crate) print_man_pages: bool,
+
+    /// If true, installs man pages.
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    pub(crate) install_man_pages: bool,
+
+    /// If true, prints shell completions.
+    #[arg(long, value_enum)]
+    pub(crate) print_shell_completions: Option<Shell>,
+
+    /// If true, installs shell completions.
+    #[cfg(target_os = "linux")]
+    #[arg(long, value_enum)]
+    pub(crate) install_shell_completions: Option<Shell>,
 
     #[command(subcommand)]
     pub(crate) commands: Option<ClientCommands>,

--- a/crates/reactive-graph/src/cli/instances/relations/args/id_and_component.rs
+++ b/crates/reactive-graph/src/cli/instances/relations/args/id_and_component.rs
@@ -1,6 +1,6 @@
 use crate::cli::error::CommandError;
 use crate::cli::instances::relations::args::id::RelationInstanceIdArgs;
-use crate::cli::types::components::args::type_id::ComponentTypeIdArgs;
+use crate::cli::types::components::args::type_id::ComponentContainerTypeIdArgs;
 use clap::Args;
 use reactive_graph_graph::RelationInstanceId;
 
@@ -13,7 +13,7 @@ pub(crate) struct RelationInstanceIdAndComponentArgs {
 
     /// The component type of the reactive instance.
     #[clap(flatten)]
-    pub component_ty: ComponentTypeIdArgs,
+    pub component_ty: ComponentContainerTypeIdArgs,
 }
 
 impl RelationInstanceIdAndComponentArgs {

--- a/crates/reactive-graph/src/client.rs
+++ b/crates/reactive-graph/src/client.rs
@@ -1,10 +1,23 @@
 use crate::cli::args::ClientArgs;
 use crate::cli::client;
+#[cfg(target_os = "linux")]
+use crate::completions::install_shell_completions;
+use crate::completions::print_shell_completions;
+#[cfg(target_os = "linux")]
+use crate::manpages::install_man_pages;
+#[cfg(target_os = "linux")]
+use crate::manpages::print_man_pages;
+use clap::CommandFactory;
 use clap::Parser;
 use std::alloc::System;
 use std::process::exit;
 
 mod cli;
+
+mod completions;
+
+#[cfg(target_os = "linux")]
+mod manpages;
 
 #[global_allocator]
 static ALLOCATOR: System = System;
@@ -15,6 +28,44 @@ async fn main() {
 
     if client_args.markdown_help {
         clap_markdown::print_help_markdown::<ClientArgs>();
+        exit(0);
+    }
+
+    // Print man pages
+    #[cfg(target_os = "linux")]
+    if client_args.print_man_pages {
+        if let Err(e) = print_man_pages(ClientArgs::command()) {
+            eprintln!("Failed to print man pages: {e}");
+            exit(1);
+        };
+        exit(0);
+    }
+
+    // Install man pages
+    #[cfg(target_os = "linux")]
+    if client_args.install_man_pages {
+        if let Err(e) = install_man_pages(ClientArgs::command()) {
+            eprintln!("Failed to install man pages: {e}");
+            exit(1);
+        }
+        exit(0);
+    }
+
+    // Print shell completions
+    if let Some(completions) = client_args.print_shell_completions {
+        let mut cmd = ClientArgs::command();
+        print_shell_completions(completions, &mut cmd);
+        exit(0);
+    }
+
+    // Install shell completions
+    #[cfg(target_os = "linux")]
+    if let Some(completions) = client_args.install_shell_completions {
+        let mut cmd = ClientArgs::command();
+        if let Err(e) = install_shell_completions(completions, completions, &mut cmd) {
+            eprintln!("Failed to install shell completions: {e}");
+            exit(1);
+        }
         exit(0);
     }
 

--- a/crates/reactive-graph/src/completions.rs
+++ b/crates/reactive-graph/src/completions.rs
@@ -1,49 +1,58 @@
 use clap::Command;
 use clap_complete::generate;
 use clap_complete::Generator;
-use clap_complete::Shell;
-use std::fs::create_dir_all;
-use thiserror::Error;
 
-#[derive(Debug, Error)]
-pub enum InstallShellCompletionError {
-    #[error("Failed to get xdg base directory: The shell {0} is not supported")]
-    UnsupportedShell(Shell),
-    #[error("Failed to get xdg base directory: {0}")]
-    BaseDirectories(#[from] xdg::BaseDirectoriesError),
-    #[error("IO Error: {0}")]
-    Io(#[from] std::io::Error),
-}
+#[cfg(target_os = "linux")]
+pub use install::install_shell_completions;
 
 pub fn print_shell_completions<G: Generator>(gen: G, cmd: &mut Command) {
     generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
 }
 
 #[cfg(target_os = "linux")]
-pub fn install_shell_completions<G: Generator>(gen: G, shell: Shell, cmd: &mut Command) -> Result<(), InstallShellCompletionError> {
-    let bin_name = cmd.get_name().to_string();
+pub mod install {
+    use clap::Command;
+    use clap_complete::generate;
+    use clap_complete::Generator;
+    use clap_complete::Shell;
+    use std::fs::create_dir_all;
+    use thiserror::Error;
 
-    let path = match shell {
-        Shell::Fish => {
-            let dirs = xdg::BaseDirectories::new().map_err(InstallShellCompletionError::BaseDirectories)?;
-            dirs.place_config_file(format!("fish/completions/{bin_name}.fish"))
-                .map_err(InstallShellCompletionError::Io)?
-        }
-        Shell::Bash => format!("/usr/share/bash-completion/completions/{bin_name}").into(),
-        Shell::Zsh => format!("/usr/share/zsh/functions/Completion/Base/_{bin_name}").into(),
-        _ => {
-            return Err(InstallShellCompletionError::UnsupportedShell(shell));
-        }
-    };
-
-    if let Some(parent) = path.parent() {
-        create_dir_all(parent).map_err(InstallShellCompletionError::Io)?;
+    #[derive(Debug, Error)]
+    pub enum InstallShellCompletionError {
+        #[error("Failed to get xdg base directory: The shell {0} is not supported")]
+        UnsupportedShell(Shell),
+        #[error("Failed to get xdg base directory: {0}")]
+        BaseDirectories(#[from] xdg::BaseDirectoriesError),
+        #[error("IO Error: {0}")]
+        Io(#[from] std::io::Error),
     }
 
-    eprintln!("Writing completions to {}", path.display());
+    pub fn install_shell_completions<G: Generator>(gen: G, shell: Shell, cmd: &mut Command) -> Result<(), InstallShellCompletionError> {
+        let bin_name = cmd.get_name().to_string();
 
-    let mut buffer = Vec::with_capacity(512);
-    generate(gen, cmd, &bin_name, &mut buffer);
-    std::fs::write(path, buffer).map_err(InstallShellCompletionError::Io)?;
-    Ok(())
+        let path = match shell {
+            Shell::Fish => {
+                let dirs = xdg::BaseDirectories::new().map_err(InstallShellCompletionError::BaseDirectories)?;
+                dirs.place_config_file(format!("fish/completions/{bin_name}.fish"))
+                    .map_err(InstallShellCompletionError::Io)?
+            }
+            Shell::Bash => format!("/usr/share/bash-completion/completions/{bin_name}").into(),
+            Shell::Zsh => format!("/usr/share/zsh/functions/Completion/Base/_{bin_name}").into(),
+            _ => {
+                return Err(InstallShellCompletionError::UnsupportedShell(shell));
+            }
+        };
+
+        if let Some(parent) = path.parent() {
+            create_dir_all(parent).map_err(InstallShellCompletionError::Io)?;
+        }
+
+        eprintln!("Writing completions to {}", path.display());
+
+        let mut buffer = Vec::with_capacity(512);
+        generate(gen, cmd, &bin_name, &mut buffer);
+        std::fs::write(path, buffer).map_err(InstallShellCompletionError::Io)?;
+        Ok(())
+    }
 }

--- a/crates/reactive-graph/src/completions.rs
+++ b/crates/reactive-graph/src/completions.rs
@@ -1,0 +1,49 @@
+use clap::Command;
+use clap_complete::generate;
+use clap_complete::Generator;
+use clap_complete::Shell;
+use std::fs::create_dir_all;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum InstallShellCompletionError {
+    #[error("Failed to get xdg base directory: The shell {0} is not supported")]
+    UnsupportedShell(Shell),
+    #[error("Failed to get xdg base directory: {0}")]
+    BaseDirectories(#[from] xdg::BaseDirectoriesError),
+    #[error("IO Error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub fn print_shell_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+}
+
+#[cfg(target_os = "linux")]
+pub fn install_shell_completions<G: Generator>(gen: G, shell: Shell, cmd: &mut Command) -> Result<(), InstallShellCompletionError> {
+    let bin_name = cmd.get_name().to_string();
+
+    let path = match shell {
+        Shell::Fish => {
+            let dirs = xdg::BaseDirectories::new().map_err(InstallShellCompletionError::BaseDirectories)?;
+            dirs.place_config_file(format!("fish/completions/{bin_name}.fish"))
+                .map_err(InstallShellCompletionError::Io)?
+        }
+        Shell::Bash => format!("/usr/share/bash-completion/completions/{bin_name}").into(),
+        Shell::Zsh => format!("/usr/share/zsh/functions/Completion/Base/_{bin_name}").into(),
+        _ => {
+            return Err(InstallShellCompletionError::UnsupportedShell(shell));
+        }
+    };
+
+    if let Some(parent) = path.parent() {
+        create_dir_all(parent).map_err(InstallShellCompletionError::Io)?;
+    }
+
+    eprintln!("Writing completions to {}", path.display());
+
+    let mut buffer = Vec::with_capacity(512);
+    generate(gen, cmd, &bin_name, &mut buffer);
+    std::fs::write(path, buffer).map_err(InstallShellCompletionError::Io)?;
+    Ok(())
+}

--- a/crates/reactive-graph/src/manpages.rs
+++ b/crates/reactive-graph/src/manpages.rs
@@ -1,0 +1,43 @@
+use clap::Command;
+use std::fs::create_dir_all;
+use std::path::PathBuf;
+use std::string::FromUtf8Error;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ManPagesGenerationError {
+    #[error("IO Error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("UTF-8 Error: {0}")]
+    Utf8(#[from] FromUtf8Error),
+}
+
+fn generate_man_pages(cmd: Command) -> Result<String, ManPagesGenerationError> {
+    let man = clap_mangen::Man::new(cmd);
+    let mut buffer: Vec<u8> = Default::default();
+    man.render(&mut buffer)?;
+
+    let man_page = String::from_utf8(buffer).map_err(ManPagesGenerationError::Utf8)?;
+    Ok(man_page)
+}
+
+pub fn print_man_pages(cmd: Command) -> Result<(), ManPagesGenerationError> {
+    let man_page = generate_man_pages(cmd)?;
+    println!("{man_page}");
+    Ok(())
+}
+
+pub fn install_man_pages(cmd: Command) -> Result<(), ManPagesGenerationError> {
+    let bin_name = cmd.get_name().to_string();
+    let path: PathBuf = format!("/usr/share/man/man1/{bin_name}.1").into();
+
+    if let Some(parent) = path.parent() {
+        create_dir_all(parent).map_err(ManPagesGenerationError::Io)?;
+    }
+
+    eprintln!("Writing man pages to {}", path.display());
+
+    let man_page = generate_man_pages(cmd)?;
+    std::fs::write(path, man_page).map_err(ManPagesGenerationError::Io)?;
+    Ok(())
+}

--- a/crates/reactive-graph/src/server/cli_args.rs
+++ b/crates/reactive-graph/src/server/cli_args.rs
@@ -1,10 +1,9 @@
-use clap::Parser;
-use clap::Subcommand;
-
 #[cfg(feature = "client")]
 use crate::cli::args::ClientArgs;
+use clap::Parser;
+use clap::Subcommand;
+use clap_complete::Shell;
 
-/// Simple program to greet a person
 #[derive(Parser, Debug)]
 #[command(name = "reactive-graph", author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -111,6 +110,25 @@ pub struct CliArguments {
     #[arg(long, hide = true)]
     pub(crate) markdown_help: bool,
 
+    /// If true, generates man pages.
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    pub(crate) print_man_pages: bool,
+
+    /// If true, installs man pages.
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    pub(crate) install_man_pages: bool,
+
+    /// If true, prints shell completions.
+    #[arg(long, value_enum)]
+    pub(crate) print_shell_completions: Option<Shell>,
+
+    /// If true, installs shell completions.
+    #[cfg(target_os = "linux")]
+    #[arg(long, value_enum)]
+    pub(crate) install_shell_completions: Option<Shell>,
+
     /// If true, the process will run as daemon.
     #[cfg(target_os = "linux")]
     #[arg(short = 'D', long, env = "REACTIVE_GRAPH_DAEMON")]
@@ -161,4 +179,22 @@ pub enum Commands {
     #[cfg(feature = "client")]
     #[non_exhaustive]
     Client(ClientArgs),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completions::print_shell_completions;
+    use clap::CommandFactory;
+
+    #[test]
+    fn test_print_completions() {
+        let mut cmd = CliArguments::command();
+        print_shell_completions(Shell::Zsh, &mut cmd);
+    }
+
+    #[test]
+    fn test_print_markdown_help() {
+        clap_markdown::print_help_markdown::<CliArguments>();
+    }
 }

--- a/crates/runtime/graphql/test/Cargo.toml
+++ b/crates/runtime/graphql/test/Cargo.toml
@@ -27,5 +27,9 @@ reactive-graph-runtime-api = { version = "0.10.0", path = "../../api" }
 reactive-graph-runtime-impl = { version = "0.10.0", path = "../../impl" }
 reactive-graph-runtime-graphql-api = { version = "0.10.0", path = "../api" }
 
+[features]
+default = []
+integration-tests = []
+
 [lib]
 crate-type = ["lib"]

--- a/crates/runtime/graphql/test/src/lib.rs
+++ b/crates/runtime/graphql/test/src/lib.rs
@@ -1,2 +1,2 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 mod tests;

--- a/crates/runtime/graphql/test/src/tests/query/remotes/fetch_remotes_from_all_remotes.rs
+++ b/crates/runtime/graphql/test/src/tests/query/remotes/fetch_remotes_from_all_remotes.rs
@@ -1,12 +1,12 @@
 use async_graphql::Request;
-use std::sync::Arc;
-
-use serde::Deserialize;
-
 use reactive_graph_remotes_model::InstanceInfo;
 use reactive_graph_runtime_api::Runtime;
 use reactive_graph_runtime_graphql_api::RuntimeQueryService;
 use reactive_graph_runtime_impl::RuntimeBuilder;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +33,8 @@ async fn test_fetch_remotes_from_all_remotes() {
         .spawn()
         .await
         .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+            sleep(Duration::from_millis(2000)).await;
+
             let query_service = runtime.get_runtime_query_service();
             let instance_service = runtime.get_instance_service();
             let remotes_manager = runtime.get_remotes_manager();

--- a/crates/runtime/graphql/test/src/tests/query/remotes/fetch_remotes_from_remote.rs
+++ b/crates/runtime/graphql/test/src/tests/query/remotes/fetch_remotes_from_remote.rs
@@ -1,14 +1,14 @@
-use async_graphql::Request;
-use std::sync::Arc;
-
-use serde::Deserialize;
-
 use crate::tests::util::address_to_vars;
+use async_graphql::Request;
 use reactive_graph_remotes_model::InstanceAddress;
 use reactive_graph_remotes_model::InstanceInfo;
 use reactive_graph_runtime_api::Runtime;
 use reactive_graph_runtime_graphql_api::RuntimeQueryService;
 use reactive_graph_runtime_impl::RuntimeBuilder;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[derive(Deserialize, Debug)]
 struct Mutation {
@@ -34,6 +34,8 @@ async fn test_fetch_remotes_from_remote() {
         .spawn()
         .await
         .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+            sleep(Duration::from_millis(2000)).await;
+
             let query_service = runtime.get_runtime_query_service();
             let instance_service = runtime.get_instance_service();
             let remotes_manager = runtime.get_remotes_manager();

--- a/crates/runtime/graphql/test/src/tests/query/remotes/get_all.rs
+++ b/crates/runtime/graphql/test/src/tests/query/remotes/get_all.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
-
-use serde::Deserialize;
-
 use reactive_graph_remotes_model::InstanceAddress;
 use reactive_graph_runtime_api::Runtime;
 use reactive_graph_runtime_graphql_api::RuntimeQueryService;
 use reactive_graph_runtime_impl::RuntimeBuilder;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -26,6 +26,8 @@ async fn test_get_all_remotes() {
         .spawn()
         .await
         .with_runtime(|runtime: Arc<dyn Runtime + Send + Sync>| async move {
+            sleep(Duration::from_millis(2000)).await;
+
             let query_service = runtime.get_runtime_query_service();
             let instance_service = runtime.get_instance_service();
             let remotes_manager = runtime.get_remotes_manager();

--- a/docs/book/src/Development_Contributing.md
+++ b/docs/book/src/Development_Contributing.md
@@ -1,0 +1,1 @@
+{{#include ../../../CONTRIBUTING.md}}

--- a/docs/book/src/Development_Security.md
+++ b/docs/book/src/Development_Security.md
@@ -1,0 +1,1 @@
+{{#include ../../../SECURITY.md}}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -94,4 +94,5 @@
     - [Packaging](./Development_Packaging.md)
     - [Documentation](./Development_Documentation.md)
     - [Contributing](./Development_Contributing.md)
+    - [Security](./Development_Security.md)
 - [Limitations](./Limitations.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -93,4 +93,5 @@
     - [Binaries](./Development_Binaries.md)
     - [Packaging](./Development_Packaging.md)
     - [Documentation](./Development_Documentation.md)
+    - [Contributing](./Development_Contributing.md)
 - [Limitations](./Limitations.md)


### PR DESCRIPTION
## CLI: Generate shell completions and man pages

1. Print shell completions (using [clap_complete](https://crates.io/crates/clap_complete))
    * `reactive-graph --print-shell-completions bash|elvish|fish|powershell|zsh` 
2. Install shell completions (Linux only)
    * `reactive-graph --install-shell-completions bash|fish|zsh`
3. Print man pages (Linux only, using [clap_mangen](https://crates.io/crates/clap_mangen))
    * `reactive-graph --print-man-pages` 
4. Install man pages
    * `reactive-graph --install-man-pages`
5. Updated contributing instructions
6. Added security policy
7. Check for changes in CHANGELOG.md for every pull request
