### PR TITLE
Docker Plugin Support (0.10.0-alpha-5)

### DIFF
--- a/.run/Reactive Graph Latest.run.xml
+++ b/.run/Reactive Graph Latest.run.xml
@@ -2,18 +2,26 @@
   <configuration default="false" name="Reactive Graph Latest" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="ghcr.io/reactive-graph/reactive-graph:latest" />
-        <option name="containerName" value="reactive-graph-latest" />
+        <option name="imageTag" value="ghcr.io/reactive-graph/reactive-graph:latest"/>
+        <option name="containerName" value="reactive-graph-latest"/>
         <option name="portBindings">
           <list>
             <DockerPortBindingImpl>
-              <option name="containerPort" value="31415" />
-              <option name="hostPort" value="31415" />
+              <option name="containerPort" value="31415"/>
+              <option name="hostPort" value="31415"/>
             </DockerPortBindingImpl>
+          </list>
+        </option>
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/opt/reactive-graph/plugins/deploy"/>
+              <option name="hostPath" value="$PROJECT_DIR$/plugins/deploy"/>
+            </DockerVolumeBindingImpl>
           </list>
         </option>
       </settings>
     </deployment>
-    <method v="2" />
+    <method v="2"/>
   </configuration>
 </component>

--- a/.run/Reactive Graph Local + Standard Library.run.xml
+++ b/.run/Reactive Graph Local + Standard Library.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Reactive Graph Local + Standard Library" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="composeProjectName" value="reactive-graph-nightly-std" />
+        <option name="envVars">
+          <list>
+            <DockerEnvVarImpl>
+              <option name="name" value="TAG" />
+              <option name="value" value="nightly" />
+            </DockerEnvVarImpl>
+            <DockerEnvVarImpl>
+              <option name="name" value="VERSION" />
+              <option name="value" value="nightly" />
+            </DockerEnvVarImpl>
+          </list>
+        </option>
+        <option name="sourceFilePath" value="docker-compose.yml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Reactive Graph Local.run.xml
+++ b/.run/Reactive Graph Local.run.xml
@@ -2,19 +2,27 @@
   <configuration default="false" name="Reactive Graph Local" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
     <deployment type="dockerfile">
       <settings>
-        <option name="imageTag" value="reactive-graph/reactive-graph:local" />
-        <option name="containerName" value="reactive-graph-local" />
+        <option name="imageTag" value="reactive-graph/reactive-graph:local"/>
+        <option name="containerName" value="reactive-graph-local"/>
         <option name="portBindings">
           <list>
             <DockerPortBindingImpl>
-              <option name="containerPort" value="31415" />
-              <option name="hostPort" value="31415" />
+              <option name="containerPort" value="31415"/>
+              <option name="hostPort" value="31415"/>
             </DockerPortBindingImpl>
           </list>
         </option>
-        <option name="sourceFilePath" value="Dockerfile" />
+        <option name="sourceFilePath" value="Dockerfile"/>
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/opt/reactive-graph/plugins/deploy"/>
+              <option name="hostPath" value="$PROJECT_DIR$/plugins/deploy"/>
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
       </settings>
     </deployment>
-    <method v="2" />
+    <method v="2"/>
   </configuration>
 </component>

--- a/.run/Reactive Graph Nightly.run.xml
+++ b/.run/Reactive Graph Nightly.run.xml
@@ -2,18 +2,26 @@
   <configuration default="false" name="Reactive Graph Nightly" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="ghcr.io/reactive-graph/reactive-graph:nightly" />
-        <option name="containerName" value="reactive-graph-nightly" />
+        <option name="imageTag" value="ghcr.io/reactive-graph/reactive-graph:nightly"/>
+        <option name="containerName" value="reactive-graph-nightly"/>
         <option name="portBindings">
           <list>
             <DockerPortBindingImpl>
-              <option name="containerPort" value="31415" />
-              <option name="hostPort" value="31415" />
+              <option name="containerPort" value="31415"/>
+              <option name="hostPort" value="31415"/>
             </DockerPortBindingImpl>
+          </list>
+        </option>
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/opt/reactive-graph/plugins/deploy"/>
+              <option name="hostPath" value="$PROJECT_DIR$/plugins/deploy"/>
+            </DockerVolumeBindingImpl>
           </list>
         </option>
       </settings>
     </deployment>
-    <method v="2" />
+    <method v="2"/>
   </configuration>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- CLI: Added arguments `--danger_accept_invalid_certs` and `--danger_accept_invalid_hostnames`
-
 ### Changed
 
 ### Fixed
@@ -18,6 +16,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Distribution
 
 ### Infrastructure
+
+## [0.10.0-alpha-5] - 2025-08-01
+
+> [!NOTE]
+> Improves plugin support in docker containers
+
+### Added
+
+- CLI: Added arguments `--danger_accept_invalid_certs` and `--danger_accept_invalid_hostnames`
+
+### Changed
+
+- Plugins: Improved error message if moving plugin from `plugins/deploy` to `plugins/installed` failed
+
+### Fixed
+
+- Docker: Run configurations for docker containers mount the plugin deploy folder of the workspace on the container (note: this works only if you're running a
+  single container)
+- Docker: Plugin system now correctly handles deploying plugins when the deploy folder is mounted as volume
+
+### Distribution
+
+- Docker: Dockerfile now uses ubuntu 24.04 as runtime image
+- Docker: Added Dockerfile.debian which uses bookworm-slim as base image
+- Docker: Added docker-compose which contains an init container for installing plugins (respects arch + configurable with a tag/version)
+
+### Infrastructure
+
+- The standard library plugins are now provided via [GitHub Releases](https://github.com/reactive-graph/std/releases/tag/nightly)
 
 ## [0.10.0-alpha-4] - 2025-07-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN useradd -d /opt/reactive-graph -s /bin/bash -g reactive-graph -u 1000 reacti
 WORKDIR /opt/reactive-graph
 RUN chown -R reactive-graph:reactive-graph .
 COPY --from=builder --chown=reactive-graph:reactive-graph /app/target/release/reactive-graph .
+RUN ./reactive-graph shell-completions install bash
+RUN ./reactive-graph shell-completions install zsh
 USER reactive-graph
 RUN ./reactive-graph instances init --uid 1000 --gid 1000
 RUN ./reactive-graph instances config graphql --hostname "0.0.0.0" --secure true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/usr/local/cargo/git --mount=type=cache,target=$SCCACHE_DIR,sharing=locked cargo build --release --bin reactive-graph
 
-FROM debian:bookworm-slim AS reactive-graph
+FROM ubuntu:24.04 AS reactive-graph
 LABEL org.opencontainers.image.title="Reactive Graph"
 LABEL org.opencontainers.image.description="Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software"
 LABEL org.opencontainers.image.vendor="Reactive Graph"
@@ -24,8 +24,9 @@ LABEL org.opencontainers.image.source="https://github.com/reactive-graph/reactiv
 LABEL org.opencontainers.image.authors="info@reactive-graph.io"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.documentation="https://docs.reactive-graph.io/book/"
-RUN apt update && apt install -y zsh nano curl
-RUN addgroup --gid 1000 reactive-graph
+RUN apt update && apt install -y zsh nano curl wget ca-certificates bash-completion
+RUN userdel -r ubuntu
+RUN groupadd --gid 1000 reactive-graph
 RUN useradd -d /opt/reactive-graph -s /bin/bash -g reactive-graph -u 1000 reactive-graph
 WORKDIR /opt/reactive-graph
 RUN chown -R reactive-graph:reactive-graph .

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,39 @@
+FROM rust:slim-bookworm AS base
+RUN apt update && apt install -y build-essential ca-certificates sccache
+RUN cargo install cargo-chef --version ^0.1
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+
+FROM base AS planner
+WORKDIR /app
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/usr/local/cargo/git --mount=type=cache,target=$SCCACHE_DIR,sharing=locked cargo chef prepare --recipe-path recipe.json
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/usr/local/cargo/git --mount=type=cache,target=$SCCACHE_DIR,sharing=locked cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/usr/local/cargo/git --mount=type=cache,target=$SCCACHE_DIR,sharing=locked cargo build --release --bin reactive-graph
+
+FROM debian:bookworm-slim AS reactive-graph
+LABEL org.opencontainers.image.title="Reactive Graph"
+LABEL org.opencontainers.image.description="Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software"
+LABEL org.opencontainers.image.vendor="Reactive Graph"
+LABEL org.opencontainers.image.url="https://www.reactive-graph.io/"
+LABEL org.opencontainers.image.source="https://github.com/reactive-graph/reactive-graph"
+LABEL org.opencontainers.image.authors="info@reactive-graph.io"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.documentation="https://docs.reactive-graph.io/book/"
+RUN apt update && apt install -y zsh nano curl
+RUN addgroup --gid 1000 reactive-graph
+RUN useradd -d /opt/reactive-graph -s /bin/bash -g reactive-graph -u 1000 reactive-graph
+WORKDIR /opt/reactive-graph
+RUN chown -R reactive-graph:reactive-graph .
+COPY --from=builder --chown=reactive-graph:reactive-graph /app/target/release/reactive-graph .
+USER reactive-graph
+RUN ./reactive-graph instances init --uid 1000 --gid 1000
+RUN ./reactive-graph instances config graphql --hostname "0.0.0.0" --secure true
+RUN ./reactive-graph instances config instance --instance-name "Reactive Graph" --instance-description "Docker"
+ENV PATH="$PATH:/opt/reactive-graph"
+EXPOSE 31415
+ENTRYPOINT [ "./reactive-graph" ]

--- a/crates/plugin/service/impl/src/plugin_repository_manager_impl.rs
+++ b/crates/plugin/service/impl/src/plugin_repository_manager_impl.rs
@@ -372,8 +372,8 @@ fn deploy_plugin(deploy_path: PathBuf) -> Result<PathBuf, HotDeployError> {
             debug!("Moved plugin from {} to {}", deploy_path.display(), install_path.display());
             Ok(install_path)
         }
-        Err(_) => {
-            error!("Failed to moved plugin from {} to {}", deploy_path.display(), install_path.display());
+        Err(e) => {
+            error!("Failed to moved plugin from {} to {}: {:?}", deploy_path.display(), install_path.display(), e);
             Err(HotDeployError::MoveError)
         }
     }

--- a/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph
+++ b/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph
@@ -37,6 +37,9 @@ _reactive-graph() {
             reactive__graph,flow-types)
                 cmd="reactive__graph__flow__types"
                 ;;
+            reactive__graph,graphql-schema)
+                cmd="reactive__graph__graphql__schema"
+                ;;
             reactive__graph,help)
                 cmd="reactive__graph__help"
                 ;;
@@ -48,6 +51,12 @@ _reactive-graph() {
                 ;;
             reactive__graph,instances)
                 cmd="reactive__graph__instances"
+                ;;
+            reactive__graph,introspection)
+                cmd="reactive__graph__introspection"
+                ;;
+            reactive__graph,json-schema)
+                cmd="reactive__graph__json__schema"
                 ;;
             reactive__graph,man-pages)
                 cmd="reactive__graph__man__pages"
@@ -66,9 +75,6 @@ _reactive-graph() {
                 ;;
             reactive__graph,remotes)
                 cmd="reactive__graph__remotes"
-                ;;
-            reactive__graph,schema)
-                cmd="reactive__graph__schema"
                 ;;
             reactive__graph,shell-completions)
                 cmd="reactive__graph__shell__completions"
@@ -93,6 +99,9 @@ _reactive-graph() {
                 ;;
             reactive__graph__components,get)
                 cmd="reactive__graph__components__get"
+                ;;
+            reactive__graph__components,get-json-schema)
+                cmd="reactive__graph__components__get__json__schema"
                 ;;
             reactive__graph__components,help)
                 cmd="reactive__graph__components__help"
@@ -132,6 +141,9 @@ _reactive-graph() {
                 ;;
             reactive__graph__components__help,get)
                 cmd="reactive__graph__components__help__get"
+                ;;
+            reactive__graph__components__help,get-json-schema)
+                cmd="reactive__graph__components__help__get__json__schema"
                 ;;
             reactive__graph__components__help,help)
                 cmd="reactive__graph__components__help__help"
@@ -265,6 +277,9 @@ _reactive-graph() {
             reactive__graph__entity__types,get)
                 cmd="reactive__graph__entity__types__get"
                 ;;
+            reactive__graph__entity__types,get-json-schema)
+                cmd="reactive__graph__entity__types__get__json__schema"
+                ;;
             reactive__graph__entity__types,help)
                 cmd="reactive__graph__entity__types__help"
                 ;;
@@ -312,6 +327,9 @@ _reactive-graph() {
                 ;;
             reactive__graph__entity__types__help,get)
                 cmd="reactive__graph__entity__types__help__get"
+                ;;
+            reactive__graph__entity__types__help,get-json-schema)
+                cmd="reactive__graph__entity__types__help__get__json__schema"
                 ;;
             reactive__graph__entity__types__help,help)
                 cmd="reactive__graph__entity__types__help__help"
@@ -403,6 +421,9 @@ _reactive-graph() {
             reactive__graph__flow__types,get)
                 cmd="reactive__graph__flow__types__get"
                 ;;
+            reactive__graph__flow__types,get-json-schema)
+                cmd="reactive__graph__flow__types__get__json__schema"
+                ;;
             reactive__graph__flow__types,help)
                 cmd="reactive__graph__flow__types__help"
                 ;;
@@ -448,6 +469,9 @@ _reactive-graph() {
             reactive__graph__flow__types__help,get)
                 cmd="reactive__graph__flow__types__help__get"
                 ;;
+            reactive__graph__flow__types__help,get-json-schema)
+                cmd="reactive__graph__flow__types__help__get__json__schema"
+                ;;
             reactive__graph__flow__types__help,help)
                 cmd="reactive__graph__flow__types__help__help"
                 ;;
@@ -475,6 +499,36 @@ _reactive-graph() {
             reactive__graph__flow__types__help,update-description)
                 cmd="reactive__graph__flow__types__help__update__description"
                 ;;
+            reactive__graph__graphql__schema,dynamic-graph-schema)
+                cmd="reactive__graph__graphql__schema__dynamic__graph__schema"
+                ;;
+            reactive__graph__graphql__schema,help)
+                cmd="reactive__graph__graphql__schema__help"
+                ;;
+            reactive__graph__graphql__schema,reactive-graph-plugin-schema)
+                cmd="reactive__graph__graphql__schema__reactive__graph__plugin__schema"
+                ;;
+            reactive__graph__graphql__schema,reactive-graph-runtime-schema)
+                cmd="reactive__graph__graphql__schema__reactive__graph__runtime__schema"
+                ;;
+            reactive__graph__graphql__schema,reactive-graph-schema)
+                cmd="reactive__graph__graphql__schema__reactive__graph__schema"
+                ;;
+            reactive__graph__graphql__schema__help,dynamic-graph-schema)
+                cmd="reactive__graph__graphql__schema__help__dynamic__graph__schema"
+                ;;
+            reactive__graph__graphql__schema__help,help)
+                cmd="reactive__graph__graphql__schema__help__help"
+                ;;
+            reactive__graph__graphql__schema__help,reactive-graph-plugin-schema)
+                cmd="reactive__graph__graphql__schema__help__reactive__graph__plugin__schema"
+                ;;
+            reactive__graph__graphql__schema__help,reactive-graph-runtime-schema)
+                cmd="reactive__graph__graphql__schema__help__reactive__graph__runtime__schema"
+                ;;
+            reactive__graph__graphql__schema__help,reactive-graph-schema)
+                cmd="reactive__graph__graphql__schema__help__reactive__graph__schema"
+                ;;
             reactive__graph__help,components)
                 cmd="reactive__graph__help__components"
                 ;;
@@ -496,6 +550,9 @@ _reactive-graph() {
             reactive__graph__help,flow-types)
                 cmd="reactive__graph__help__flow__types"
                 ;;
+            reactive__graph__help,graphql-schema)
+                cmd="reactive__graph__help__graphql__schema"
+                ;;
             reactive__graph__help,help)
                 cmd="reactive__graph__help__help"
                 ;;
@@ -507,6 +564,12 @@ _reactive-graph() {
                 ;;
             reactive__graph__help,instances)
                 cmd="reactive__graph__help__instances"
+                ;;
+            reactive__graph__help,introspection)
+                cmd="reactive__graph__help__introspection"
+                ;;
+            reactive__graph__help,json-schema)
+                cmd="reactive__graph__help__json__schema"
                 ;;
             reactive__graph__help,man-pages)
                 cmd="reactive__graph__help__man__pages"
@@ -525,9 +588,6 @@ _reactive-graph() {
                 ;;
             reactive__graph__help,remotes)
                 cmd="reactive__graph__help__remotes"
-                ;;
-            reactive__graph__help,schema)
-                cmd="reactive__graph__help__schema"
                 ;;
             reactive__graph__help,shell-completions)
                 cmd="reactive__graph__help__shell__completions"
@@ -552,6 +612,9 @@ _reactive-graph() {
                 ;;
             reactive__graph__help__components,get)
                 cmd="reactive__graph__help__components__get"
+                ;;
+            reactive__graph__help__components,get-json-schema)
+                cmd="reactive__graph__help__components__get__json__schema"
                 ;;
             reactive__graph__help__components,json-schema)
                 cmd="reactive__graph__help__components__json__schema"
@@ -634,6 +697,9 @@ _reactive-graph() {
             reactive__graph__help__entity__types,get)
                 cmd="reactive__graph__help__entity__types__get"
                 ;;
+            reactive__graph__help__entity__types,get-json-schema)
+                cmd="reactive__graph__help__entity__types__get__json__schema"
+                ;;
             reactive__graph__help__entity__types,json-schema)
                 cmd="reactive__graph__help__entity__types__json__schema"
                 ;;
@@ -697,6 +763,9 @@ _reactive-graph() {
             reactive__graph__help__flow__types,get)
                 cmd="reactive__graph__help__flow__types__get"
                 ;;
+            reactive__graph__help__flow__types,get-json-schema)
+                cmd="reactive__graph__help__flow__types__get__json__schema"
+                ;;
             reactive__graph__help__flow__types,json-schema)
                 cmd="reactive__graph__help__flow__types__json__schema"
                 ;;
@@ -720,6 +789,18 @@ _reactive-graph() {
                 ;;
             reactive__graph__help__flow__types,update-description)
                 cmd="reactive__graph__help__flow__types__update__description"
+                ;;
+            reactive__graph__help__graphql__schema,dynamic-graph-schema)
+                cmd="reactive__graph__help__graphql__schema__dynamic__graph__schema"
+                ;;
+            reactive__graph__help__graphql__schema,reactive-graph-plugin-schema)
+                cmd="reactive__graph__help__graphql__schema__reactive__graph__plugin__schema"
+                ;;
+            reactive__graph__help__graphql__schema,reactive-graph-runtime-schema)
+                cmd="reactive__graph__help__graphql__schema__reactive__graph__runtime__schema"
+                ;;
+            reactive__graph__help__graphql__schema,reactive-graph-schema)
+                cmd="reactive__graph__help__graphql__schema__reactive__graph__schema"
                 ;;
             reactive__graph__help__instance__info,get)
                 cmd="reactive__graph__help__instance__info__get"
@@ -759,6 +840,45 @@ _reactive-graph() {
                 ;;
             reactive__graph__help__instances__repository,remove)
                 cmd="reactive__graph__help__instances__repository__remove"
+                ;;
+            reactive__graph__help__introspection,dynamic-graph)
+                cmd="reactive__graph__help__introspection__dynamic__graph"
+                ;;
+            reactive__graph__help__introspection,reactive-graph)
+                cmd="reactive__graph__help__introspection__reactive__graph"
+                ;;
+            reactive__graph__help__introspection,reactive-graph-plugins)
+                cmd="reactive__graph__help__introspection__reactive__graph__plugins"
+                ;;
+            reactive__graph__help__introspection,reactive-graph-runtime)
+                cmd="reactive__graph__help__introspection__reactive__graph__runtime"
+                ;;
+            reactive__graph__help__json__schema,instances)
+                cmd="reactive__graph__help__json__schema__instances"
+                ;;
+            reactive__graph__help__json__schema,types)
+                cmd="reactive__graph__help__json__schema__types"
+                ;;
+            reactive__graph__help__json__schema__instances,entities)
+                cmd="reactive__graph__help__json__schema__instances__entities"
+                ;;
+            reactive__graph__help__json__schema__instances,flows)
+                cmd="reactive__graph__help__json__schema__instances__flows"
+                ;;
+            reactive__graph__help__json__schema__instances,relations)
+                cmd="reactive__graph__help__json__schema__instances__relations"
+                ;;
+            reactive__graph__help__json__schema__types,components)
+                cmd="reactive__graph__help__json__schema__types__components"
+                ;;
+            reactive__graph__help__json__schema__types,entities)
+                cmd="reactive__graph__help__json__schema__types__entities"
+                ;;
+            reactive__graph__help__json__schema__types,flows)
+                cmd="reactive__graph__help__json__schema__types__flows"
+                ;;
+            reactive__graph__help__json__schema__types,relations)
+                cmd="reactive__graph__help__json__schema__types__relations"
                 ;;
             reactive__graph__help__man__pages,install)
                 cmd="reactive__graph__help__man__pages__install"
@@ -850,6 +970,9 @@ _reactive-graph() {
             reactive__graph__help__relation__types,get)
                 cmd="reactive__graph__help__relation__types__get"
                 ;;
+            reactive__graph__help__relation__types,get-json-schema)
+                cmd="reactive__graph__help__relation__types__get__json__schema"
+                ;;
             reactive__graph__help__relation__types,json-schema)
                 cmd="reactive__graph__help__relation__types__json__schema"
                 ;;
@@ -900,18 +1023,6 @@ _reactive-graph() {
                 ;;
             reactive__graph__help__remotes,update-all)
                 cmd="reactive__graph__help__remotes__update__all"
-                ;;
-            reactive__graph__help__schema,dynamic-graph-schema)
-                cmd="reactive__graph__help__schema__dynamic__graph__schema"
-                ;;
-            reactive__graph__help__schema,reactive-graph-plugin-schema)
-                cmd="reactive__graph__help__schema__reactive__graph__plugin__schema"
-                ;;
-            reactive__graph__help__schema,reactive-graph-runtime-schema)
-                cmd="reactive__graph__help__schema__reactive__graph__runtime__schema"
-                ;;
-            reactive__graph__help__schema,reactive-graph-schema)
-                cmd="reactive__graph__help__schema__reactive__graph__schema"
                 ;;
             reactive__graph__help__shell__completions,install)
                 cmd="reactive__graph__help__shell__completions__install"
@@ -1053,6 +1164,129 @@ _reactive-graph() {
                 ;;
             reactive__graph__instances__repository__help,remove)
                 cmd="reactive__graph__instances__repository__help__remove"
+                ;;
+            reactive__graph__introspection,dynamic-graph)
+                cmd="reactive__graph__introspection__dynamic__graph"
+                ;;
+            reactive__graph__introspection,help)
+                cmd="reactive__graph__introspection__help"
+                ;;
+            reactive__graph__introspection,reactive-graph)
+                cmd="reactive__graph__introspection__reactive__graph"
+                ;;
+            reactive__graph__introspection,reactive-graph-plugins)
+                cmd="reactive__graph__introspection__reactive__graph__plugins"
+                ;;
+            reactive__graph__introspection,reactive-graph-runtime)
+                cmd="reactive__graph__introspection__reactive__graph__runtime"
+                ;;
+            reactive__graph__introspection__help,dynamic-graph)
+                cmd="reactive__graph__introspection__help__dynamic__graph"
+                ;;
+            reactive__graph__introspection__help,help)
+                cmd="reactive__graph__introspection__help__help"
+                ;;
+            reactive__graph__introspection__help,reactive-graph)
+                cmd="reactive__graph__introspection__help__reactive__graph"
+                ;;
+            reactive__graph__introspection__help,reactive-graph-plugins)
+                cmd="reactive__graph__introspection__help__reactive__graph__plugins"
+                ;;
+            reactive__graph__introspection__help,reactive-graph-runtime)
+                cmd="reactive__graph__introspection__help__reactive__graph__runtime"
+                ;;
+            reactive__graph__json__schema,help)
+                cmd="reactive__graph__json__schema__help"
+                ;;
+            reactive__graph__json__schema,instances)
+                cmd="reactive__graph__json__schema__instances"
+                ;;
+            reactive__graph__json__schema,types)
+                cmd="reactive__graph__json__schema__types"
+                ;;
+            reactive__graph__json__schema__help,help)
+                cmd="reactive__graph__json__schema__help__help"
+                ;;
+            reactive__graph__json__schema__help,instances)
+                cmd="reactive__graph__json__schema__help__instances"
+                ;;
+            reactive__graph__json__schema__help,types)
+                cmd="reactive__graph__json__schema__help__types"
+                ;;
+            reactive__graph__json__schema__help__instances,entities)
+                cmd="reactive__graph__json__schema__help__instances__entities"
+                ;;
+            reactive__graph__json__schema__help__instances,flows)
+                cmd="reactive__graph__json__schema__help__instances__flows"
+                ;;
+            reactive__graph__json__schema__help__instances,relations)
+                cmd="reactive__graph__json__schema__help__instances__relations"
+                ;;
+            reactive__graph__json__schema__help__types,components)
+                cmd="reactive__graph__json__schema__help__types__components"
+                ;;
+            reactive__graph__json__schema__help__types,entities)
+                cmd="reactive__graph__json__schema__help__types__entities"
+                ;;
+            reactive__graph__json__schema__help__types,flows)
+                cmd="reactive__graph__json__schema__help__types__flows"
+                ;;
+            reactive__graph__json__schema__help__types,relations)
+                cmd="reactive__graph__json__schema__help__types__relations"
+                ;;
+            reactive__graph__json__schema__instances,entities)
+                cmd="reactive__graph__json__schema__instances__entities"
+                ;;
+            reactive__graph__json__schema__instances,flows)
+                cmd="reactive__graph__json__schema__instances__flows"
+                ;;
+            reactive__graph__json__schema__instances,help)
+                cmd="reactive__graph__json__schema__instances__help"
+                ;;
+            reactive__graph__json__schema__instances,relations)
+                cmd="reactive__graph__json__schema__instances__relations"
+                ;;
+            reactive__graph__json__schema__instances__help,entities)
+                cmd="reactive__graph__json__schema__instances__help__entities"
+                ;;
+            reactive__graph__json__schema__instances__help,flows)
+                cmd="reactive__graph__json__schema__instances__help__flows"
+                ;;
+            reactive__graph__json__schema__instances__help,help)
+                cmd="reactive__graph__json__schema__instances__help__help"
+                ;;
+            reactive__graph__json__schema__instances__help,relations)
+                cmd="reactive__graph__json__schema__instances__help__relations"
+                ;;
+            reactive__graph__json__schema__types,components)
+                cmd="reactive__graph__json__schema__types__components"
+                ;;
+            reactive__graph__json__schema__types,entities)
+                cmd="reactive__graph__json__schema__types__entities"
+                ;;
+            reactive__graph__json__schema__types,flows)
+                cmd="reactive__graph__json__schema__types__flows"
+                ;;
+            reactive__graph__json__schema__types,help)
+                cmd="reactive__graph__json__schema__types__help"
+                ;;
+            reactive__graph__json__schema__types,relations)
+                cmd="reactive__graph__json__schema__types__relations"
+                ;;
+            reactive__graph__json__schema__types__help,components)
+                cmd="reactive__graph__json__schema__types__help__components"
+                ;;
+            reactive__graph__json__schema__types__help,entities)
+                cmd="reactive__graph__json__schema__types__help__entities"
+                ;;
+            reactive__graph__json__schema__types__help,flows)
+                cmd="reactive__graph__json__schema__types__help__flows"
+                ;;
+            reactive__graph__json__schema__types__help,help)
+                cmd="reactive__graph__json__schema__types__help__help"
+                ;;
+            reactive__graph__json__schema__types__help,relations)
+                cmd="reactive__graph__json__schema__types__help__relations"
                 ;;
             reactive__graph__man__pages,help)
                 cmd="reactive__graph__man__pages__help"
@@ -1234,6 +1468,9 @@ _reactive-graph() {
             reactive__graph__relation__types,get)
                 cmd="reactive__graph__relation__types__get"
                 ;;
+            reactive__graph__relation__types,get-json-schema)
+                cmd="reactive__graph__relation__types__get__json__schema"
+                ;;
             reactive__graph__relation__types,help)
                 cmd="reactive__graph__relation__types__help"
                 ;;
@@ -1281,6 +1518,9 @@ _reactive-graph() {
                 ;;
             reactive__graph__relation__types__help,get)
                 cmd="reactive__graph__relation__types__help__get"
+                ;;
+            reactive__graph__relation__types__help,get-json-schema)
+                cmd="reactive__graph__relation__types__help__get__json__schema"
                 ;;
             reactive__graph__relation__types__help,help)
                 cmd="reactive__graph__relation__types__help__help"
@@ -1366,36 +1606,6 @@ _reactive-graph() {
             reactive__graph__remotes__help,update-all)
                 cmd="reactive__graph__remotes__help__update__all"
                 ;;
-            reactive__graph__schema,dynamic-graph-schema)
-                cmd="reactive__graph__schema__dynamic__graph__schema"
-                ;;
-            reactive__graph__schema,help)
-                cmd="reactive__graph__schema__help"
-                ;;
-            reactive__graph__schema,reactive-graph-plugin-schema)
-                cmd="reactive__graph__schema__reactive__graph__plugin__schema"
-                ;;
-            reactive__graph__schema,reactive-graph-runtime-schema)
-                cmd="reactive__graph__schema__reactive__graph__runtime__schema"
-                ;;
-            reactive__graph__schema,reactive-graph-schema)
-                cmd="reactive__graph__schema__reactive__graph__schema"
-                ;;
-            reactive__graph__schema__help,dynamic-graph-schema)
-                cmd="reactive__graph__schema__help__dynamic__graph__schema"
-                ;;
-            reactive__graph__schema__help,help)
-                cmd="reactive__graph__schema__help__help"
-                ;;
-            reactive__graph__schema__help,reactive-graph-plugin-schema)
-                cmd="reactive__graph__schema__help__reactive__graph__plugin__schema"
-                ;;
-            reactive__graph__schema__help,reactive-graph-runtime-schema)
-                cmd="reactive__graph__schema__help__reactive__graph__runtime__schema"
-                ;;
-            reactive__graph__schema__help,reactive-graph-schema)
-                cmd="reactive__graph__schema__help__reactive__graph__schema"
-                ;;
             reactive__graph__shell__completions,help)
                 cmd="reactive__graph__shell__completions__help"
                 ;;
@@ -1439,7 +1649,7 @@ _reactive-graph() {
 
     case "${cmd}" in
         reactive__graph)
-            opts="-n -d -w -c -x -p -P -q -i -h -V --logging-config --instance-config --graphql-config --plugins-config --instance-name --instance-description --hostname --port --secure --ssl-certificate-path --ssl-private-key-path --shutdown-timeout --workers --default-context-path --disable-all-plugins --disabled-plugins --enabled-plugins --disable-hot-deploy --hot-deploy-location --install-location --stop-immediately --quiet --client-hostname --client-port --client-secure --endpoint-graphql --endpoint-dynamic-graph --endpoint-runtime --endpoint-plugins --bearer --interactive --help --version shell-completions man-pages print-markdown-help info daemon schema execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances instances update help"
+            opts="-n -d -w -c -x -p -P -q -i -h -V --logging-config --instance-config --graphql-config --plugins-config --instance-name --instance-description --hostname --port --secure --ssl-certificate-path --ssl-private-key-path --shutdown-timeout --workers --default-context-path --disable-all-plugins --disabled-plugins --enabled-plugins --disable-hot-deploy --hot-deploy-location --install-location --stop-immediately --quiet --client-hostname --client-port --client-secure --endpoint-graphql --endpoint-dynamic-graph --endpoint-runtime --endpoint-plugins --bearer --danger-accept-invalid-certs --interactive --help --version true false shell-completions man-pages print-markdown-help info daemon graphql-schema json-schema execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances introspection instances update help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1597,6 +1807,10 @@ _reactive-graph() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --danger-accept-invalid-certs)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1605,7 +1819,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__components)
-            opts="-o -h -V --output-format --help --version list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions get-json-schema create delete add-property remove-property add-extension remove-extension update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1736,8 +1950,30 @@ _reactive-graph() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__components__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__components__help)
-            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description json-schema help"
+            opts="list get list-properties list-extensions get-json-schema create delete add-property remove-property add-extension remove-extension update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1807,6 +2043,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__components__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__components__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -2751,7 +3001,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__entity__types)
-            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2904,8 +3154,30 @@ _reactive-graph() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__entity__types__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__entity__types__help)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2989,6 +3261,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__entity__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__entity__types__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -3673,7 +3959,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__flow__types)
-            opts="-o -h -V --output-format --help --version list get list-variables list-extensions create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-variables list-extensions get-json-schema create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3850,8 +4136,30 @@ _reactive-graph() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__flow__types__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__flow__types__help)
-            opts="list get list-variables list-extensions create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
+            opts="list get list-variables list-extensions get-json-schema create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3935,6 +4243,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__flow__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__flow__types__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4250,8 +4572,162 @@ _reactive-graph() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__graphql__schema)
+            opts="-h -V --help --version reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__dynamic__graph__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__help)
+            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__help__dynamic__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__help__reactive__graph__plugin__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__help__reactive__graph__runtime__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__help__reactive__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__reactive__graph__plugin__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__reactive__graph__runtime__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__graphql__schema__reactive__graph__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__help)
-            opts="shell-completions man-pages print-markdown-help info daemon schema execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances instances update help"
+            opts="shell-completions man-pages print-markdown-help info daemon graphql-schema json-schema execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances introspection instances update help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4265,7 +4741,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__components)
-            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description json-schema"
+            opts="list get list-properties list-extensions get-json-schema create delete add-property remove-property add-extension remove-extension update-description json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4335,6 +4811,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__components__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__components__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4671,7 +5161,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__entity__types)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4755,6 +5245,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__entity__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__entity__types__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5007,7 +5511,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__flow__types)
-            opts="list get list-variables list-extensions create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema"
+            opts="list get list-variables list-extensions get-json-schema create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5091,6 +5595,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__flow__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__flow__types__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5203,6 +5721,76 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__flow__types__update__description)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__graphql__schema)
+            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__graphql__schema__dynamic__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__graphql__schema__reactive__graph__plugin__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__graphql__schema__reactive__graph__runtime__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__graphql__schema__reactive__graph__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5441,6 +6029,216 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__instances__repository__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__introspection)
+            opts="reactive-graph dynamic-graph reactive-graph-runtime reactive-graph-plugins"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__introspection__dynamic__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__introspection__reactive__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__introspection__reactive__graph__plugins)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__introspection__reactive__graph__runtime)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema)
+            opts="types instances"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__instances)
+            opts="entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__instances__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__instances__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__instances__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__types)
+            opts="components entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__types__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__types__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__types__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__json__schema__types__relations)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5847,7 +6645,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__relation__types)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5931,6 +6729,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__relation__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__help__relation__types__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -6183,76 +6995,6 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__help__remotes__update__all)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__help__schema)
-            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__help__schema__dynamic__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__help__schema__reactive__graph__plugin__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__help__schema__reactive__graph__runtime__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__help__schema__reactive__graph__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -7108,6 +7850,608 @@ _reactive-graph() {
             ;;
         reactive__graph__instances__repository__remove)
             opts="-h -V --help --version <LOCAL_NAME> true false"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection)
+            opts="-h -V --help --version reactive-graph dynamic-graph reactive-graph-runtime reactive-graph-plugins help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__dynamic__graph)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__help)
+            opts="reactive-graph dynamic-graph reactive-graph-runtime reactive-graph-plugins help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__help__dynamic__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__help__reactive__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__help__reactive__graph__plugins)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__help__reactive__graph__runtime)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__reactive__graph)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__reactive__graph__plugins)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__introspection__reactive__graph__runtime)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema)
+            opts="-h -V --help --version types instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help)
+            opts="types instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__instances)
+            opts="entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__instances__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__instances__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__instances__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__types)
+            opts="components entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__types__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__types__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__types__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__help__types__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances)
+            opts="-h -V --help --version entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__entities)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__flows)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__help)
+            opts="entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__help__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__help__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__help__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__instances__relations)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types)
+            opts="-h -V --help --version components entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__components)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__entities)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__flows)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__help)
+            opts="components entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__help__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__help__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__help__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__help__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__json__schema__types__relations)
+            opts="-h -V --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8245,7 +9589,7 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__relation__types)
-            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8398,8 +9742,30 @@ _reactive-graph() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__relation__types__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__relation__types__help)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -8483,6 +9849,20 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__relation__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__relation__types__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -9135,160 +10515,6 @@ _reactive-graph() {
             return 0
             ;;
         reactive__graph__remotes__update__all)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema)
-            opts="-h -V --help --version reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__dynamic__graph__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__help)
-            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__help__dynamic__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__help__help)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__help__reactive__graph__plugin__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__help__reactive__graph__runtime__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__help__reactive__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__reactive__graph__plugin__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__reactive__graph__runtime__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__schema__reactive__graph__schema)
             opts="-h -V --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph-client
+++ b/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph-client
@@ -43,6 +43,9 @@ _reactive-graph-client() {
             reactive__graph__client,instance-info)
                 cmd="reactive__graph__client__instance__info"
                 ;;
+            reactive__graph__client,introspection)
+                cmd="reactive__graph__client__introspection"
+                ;;
             reactive__graph__client,man-pages)
                 cmd="reactive__graph__client__man__pages"
                 ;;
@@ -82,6 +85,9 @@ _reactive-graph-client() {
             reactive__graph__client__components,get)
                 cmd="reactive__graph__client__components__get"
                 ;;
+            reactive__graph__client__components,get-json-schema)
+                cmd="reactive__graph__client__components__get__json__schema"
+                ;;
             reactive__graph__client__components,help)
                 cmd="reactive__graph__client__components__help"
                 ;;
@@ -120,6 +126,9 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__components__help,get)
                 cmd="reactive__graph__client__components__help__get"
+                ;;
+            reactive__graph__client__components__help,get-json-schema)
+                cmd="reactive__graph__client__components__help__get__json__schema"
                 ;;
             reactive__graph__client__components__help,help)
                 cmd="reactive__graph__client__components__help__help"
@@ -253,6 +262,9 @@ _reactive-graph-client() {
             reactive__graph__client__entity__types,get)
                 cmd="reactive__graph__client__entity__types__get"
                 ;;
+            reactive__graph__client__entity__types,get-json-schema)
+                cmd="reactive__graph__client__entity__types__get__json__schema"
+                ;;
             reactive__graph__client__entity__types,help)
                 cmd="reactive__graph__client__entity__types__help"
                 ;;
@@ -300,6 +312,9 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__entity__types__help,get)
                 cmd="reactive__graph__client__entity__types__help__get"
+                ;;
+            reactive__graph__client__entity__types__help,get-json-schema)
+                cmd="reactive__graph__client__entity__types__help__get__json__schema"
                 ;;
             reactive__graph__client__entity__types__help,help)
                 cmd="reactive__graph__client__entity__types__help__help"
@@ -391,6 +406,9 @@ _reactive-graph-client() {
             reactive__graph__client__flow__types,get)
                 cmd="reactive__graph__client__flow__types__get"
                 ;;
+            reactive__graph__client__flow__types,get-json-schema)
+                cmd="reactive__graph__client__flow__types__get__json__schema"
+                ;;
             reactive__graph__client__flow__types,help)
                 cmd="reactive__graph__client__flow__types__help"
                 ;;
@@ -435,6 +453,9 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__flow__types__help,get)
                 cmd="reactive__graph__client__flow__types__help__get"
+                ;;
+            reactive__graph__client__flow__types__help,get-json-schema)
+                cmd="reactive__graph__client__flow__types__help__get__json__schema"
                 ;;
             reactive__graph__client__flow__types__help,help)
                 cmd="reactive__graph__client__flow__types__help__help"
@@ -490,6 +511,9 @@ _reactive-graph-client() {
             reactive__graph__client__help,instance-info)
                 cmd="reactive__graph__client__help__instance__info"
                 ;;
+            reactive__graph__client__help,introspection)
+                cmd="reactive__graph__client__help__introspection"
+                ;;
             reactive__graph__client__help,man-pages)
                 cmd="reactive__graph__client__help__man__pages"
                 ;;
@@ -528,6 +552,9 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__help__components,get)
                 cmd="reactive__graph__client__help__components__get"
+                ;;
+            reactive__graph__client__help__components,get-json-schema)
+                cmd="reactive__graph__client__help__components__get__json__schema"
                 ;;
             reactive__graph__client__help__components,json-schema)
                 cmd="reactive__graph__client__help__components__json__schema"
@@ -610,6 +637,9 @@ _reactive-graph-client() {
             reactive__graph__client__help__entity__types,get)
                 cmd="reactive__graph__client__help__entity__types__get"
                 ;;
+            reactive__graph__client__help__entity__types,get-json-schema)
+                cmd="reactive__graph__client__help__entity__types__get__json__schema"
+                ;;
             reactive__graph__client__help__entity__types,json-schema)
                 cmd="reactive__graph__client__help__entity__types__json__schema"
                 ;;
@@ -673,6 +703,9 @@ _reactive-graph-client() {
             reactive__graph__client__help__flow__types,get)
                 cmd="reactive__graph__client__help__flow__types__get"
                 ;;
+            reactive__graph__client__help__flow__types,get-json-schema)
+                cmd="reactive__graph__client__help__flow__types__get__json__schema"
+                ;;
             reactive__graph__client__help__flow__types,json-schema)
                 cmd="reactive__graph__client__help__flow__types__json__schema"
                 ;;
@@ -699,6 +732,18 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__help__instance__info,get)
                 cmd="reactive__graph__client__help__instance__info__get"
+                ;;
+            reactive__graph__client__help__introspection,dynamic-graph)
+                cmd="reactive__graph__client__help__introspection__dynamic__graph"
+                ;;
+            reactive__graph__client__help__introspection,reactive-graph)
+                cmd="reactive__graph__client__help__introspection__reactive__graph"
+                ;;
+            reactive__graph__client__help__introspection,reactive-graph-plugins)
+                cmd="reactive__graph__client__help__introspection__reactive__graph__plugins"
+                ;;
+            reactive__graph__client__help__introspection,reactive-graph-runtime)
+                cmd="reactive__graph__client__help__introspection__reactive__graph__runtime"
                 ;;
             reactive__graph__client__help__man__pages,install)
                 cmd="reactive__graph__client__help__man__pages__install"
@@ -790,6 +835,9 @@ _reactive-graph-client() {
             reactive__graph__client__help__relation__types,get)
                 cmd="reactive__graph__client__help__relation__types__get"
                 ;;
+            reactive__graph__client__help__relation__types,get-json-schema)
+                cmd="reactive__graph__client__help__relation__types__get__json__schema"
+                ;;
             reactive__graph__client__help__relation__types,json-schema)
                 cmd="reactive__graph__client__help__relation__types__json__schema"
                 ;;
@@ -858,6 +906,36 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__instance__info__help,help)
                 cmd="reactive__graph__client__instance__info__help__help"
+                ;;
+            reactive__graph__client__introspection,dynamic-graph)
+                cmd="reactive__graph__client__introspection__dynamic__graph"
+                ;;
+            reactive__graph__client__introspection,help)
+                cmd="reactive__graph__client__introspection__help"
+                ;;
+            reactive__graph__client__introspection,reactive-graph)
+                cmd="reactive__graph__client__introspection__reactive__graph"
+                ;;
+            reactive__graph__client__introspection,reactive-graph-plugins)
+                cmd="reactive__graph__client__introspection__reactive__graph__plugins"
+                ;;
+            reactive__graph__client__introspection,reactive-graph-runtime)
+                cmd="reactive__graph__client__introspection__reactive__graph__runtime"
+                ;;
+            reactive__graph__client__introspection__help,dynamic-graph)
+                cmd="reactive__graph__client__introspection__help__dynamic__graph"
+                ;;
+            reactive__graph__client__introspection__help,help)
+                cmd="reactive__graph__client__introspection__help__help"
+                ;;
+            reactive__graph__client__introspection__help,reactive-graph)
+                cmd="reactive__graph__client__introspection__help__reactive__graph"
+                ;;
+            reactive__graph__client__introspection__help,reactive-graph-plugins)
+                cmd="reactive__graph__client__introspection__help__reactive__graph__plugins"
+                ;;
+            reactive__graph__client__introspection__help,reactive-graph-runtime)
+                cmd="reactive__graph__client__introspection__help__reactive__graph__runtime"
                 ;;
             reactive__graph__client__man__pages,help)
                 cmd="reactive__graph__client__man__pages__help"
@@ -1039,6 +1117,9 @@ _reactive-graph-client() {
             reactive__graph__client__relation__types,get)
                 cmd="reactive__graph__client__relation__types__get"
                 ;;
+            reactive__graph__client__relation__types,get-json-schema)
+                cmd="reactive__graph__client__relation__types__get__json__schema"
+                ;;
             reactive__graph__client__relation__types,help)
                 cmd="reactive__graph__client__relation__types__help"
                 ;;
@@ -1086,6 +1167,9 @@ _reactive-graph-client() {
                 ;;
             reactive__graph__client__relation__types__help,get)
                 cmd="reactive__graph__client__relation__types__help__get"
+                ;;
+            reactive__graph__client__relation__types__help,get-json-schema)
+                cmd="reactive__graph__client__relation__types__help__get__json__schema"
                 ;;
             reactive__graph__client__relation__types__help,help)
                 cmd="reactive__graph__client__relation__types__help__help"
@@ -1196,7 +1280,7 @@ _reactive-graph-client() {
 
     case "${cmd}" in
         reactive__graph__client)
-            opts="-h -V --client-hostname --client-port --client-secure --endpoint-graphql --endpoint-dynamic-graph --endpoint-runtime --endpoint-plugins --bearer --help --version shell-completions man-pages print-markdown-help info execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances help"
+            opts="-h -V --client-hostname --client-port --client-secure --endpoint-graphql --endpoint-dynamic-graph --endpoint-runtime --endpoint-plugins --bearer --danger-accept-invalid-certs --help --version true false shell-completions man-pages print-markdown-help info execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances introspection help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1234,6 +1318,10 @@ _reactive-graph-client() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --danger-accept-invalid-certs)
+                    COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -1242,7 +1330,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__components)
-            opts="-o -h -V --output-format --help --version list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions get-json-schema create delete add-property remove-property add-extension remove-extension update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1373,8 +1461,30 @@ _reactive-graph-client() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__client__components__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__client__components__help)
-            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description json-schema help"
+            opts="list get list-properties list-extensions get-json-schema create delete add-property remove-property add-extension remove-extension update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1444,6 +1554,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__components__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__components__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -2346,7 +2470,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__entity__types)
-            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2499,8 +2623,30 @@ _reactive-graph-client() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__client__entity__types__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__client__entity__types__help)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2584,6 +2730,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__entity__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__entity__types__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -3268,7 +3428,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__flow__types)
-            opts="-o -h -V --output-format --help --version list get list-variables list-extensions create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-variables list-extensions get-json-schema create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3445,8 +3605,30 @@ _reactive-graph-client() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__client__flow__types__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__client__flow__types__help)
-            opts="list get list-variables list-extensions create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
+            opts="list get list-variables list-extensions get-json-schema create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3530,6 +3712,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__flow__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__flow__types__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -3846,7 +4042,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help)
-            opts="shell-completions man-pages print-markdown-help info execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances help"
+            opts="shell-completions man-pages print-markdown-help info execute-command instance-info plugins remotes shutdown components entity-types relation-types flow-types entity-instances relation-instances flow-instances introspection help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3860,7 +4056,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__components)
-            opts="list get list-properties list-extensions create delete add-property remove-property add-extension remove-extension update-description json-schema"
+            opts="list get list-properties list-extensions get-json-schema create delete add-property remove-property add-extension remove-extension update-description json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3930,6 +4126,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__components__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__components__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4252,7 +4462,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__entity__types)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4336,6 +4546,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__entity__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__entity__types__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4588,7 +4812,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__flow__types)
-            opts="list get list-variables list-extensions create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema"
+            opts="list get list-variables list-extensions get-json-schema create delete add-variable remove-variable add-extension remove-extension update-description add-entity-instance remove-entity-instance json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4672,6 +4896,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__flow__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__flow__types__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4840,6 +5078,76 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__instance__info__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__introspection)
+            opts="reactive-graph dynamic-graph reactive-graph-runtime reactive-graph-plugins"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__introspection__dynamic__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__introspection__reactive__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__introspection__reactive__graph__plugins)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__introspection__reactive__graph__runtime)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5246,7 +5554,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__relation__types)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5330,6 +5638,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__help__relation__types__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__help__relation__types__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5728,6 +6050,160 @@ _reactive-graph-client() {
         reactive__graph__client__instance__info__help__help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection)
+            opts="-h -V --help --version reactive-graph dynamic-graph reactive-graph-runtime reactive-graph-plugins help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__dynamic__graph)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__help)
+            opts="reactive-graph dynamic-graph reactive-graph-runtime reactive-graph-plugins help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__help__dynamic__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__help__reactive__graph)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__help__reactive__graph__plugins)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__help__reactive__graph__runtime)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__reactive__graph)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__reactive__graph__plugins)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__introspection__reactive__graph__runtime)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -6864,7 +7340,7 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__relation__types)
-            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="-o -h -V --output-format --help --version list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7017,8 +7493,30 @@ _reactive-graph-client() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__client__relation__types__get__json__schema)
+            opts="-o -h -V --output-format --help --version <NAMESPACE> <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --output-format)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__client__relation__types__help)
-            opts="list get list-properties list-extensions list-components create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
+            opts="list get list-properties list-extensions list-components get-json-schema create delete add-property remove-property add-extension remove-extension add-component remove-component update-description json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -7102,6 +7600,20 @@ _reactive-graph-client() {
             return 0
             ;;
         reactive__graph__client__relation__types__help__get)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__client__relation__types__help__get__json__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph-server
+++ b/crates/reactive-graph/debian/usr/share/bash-completion/completions/reactive-graph-server
@@ -19,11 +19,17 @@ _reactive-graph-server() {
             reactive__graph__server,daemon)
                 cmd="reactive__graph__server__daemon"
                 ;;
+            reactive__graph__server,graphql-schema)
+                cmd="reactive__graph__server__graphql__schema"
+                ;;
             reactive__graph__server,help)
                 cmd="reactive__graph__server__help"
                 ;;
             reactive__graph__server,info)
                 cmd="reactive__graph__server__info"
+                ;;
+            reactive__graph__server,json-schema)
+                cmd="reactive__graph__server__json__schema"
                 ;;
             reactive__graph__server,man-pages)
                 cmd="reactive__graph__server__man__pages"
@@ -31,14 +37,44 @@ _reactive-graph-server() {
             reactive__graph__server,print-markdown-help)
                 cmd="reactive__graph__server__print__markdown__help"
                 ;;
-            reactive__graph__server,schema)
-                cmd="reactive__graph__server__schema"
-                ;;
             reactive__graph__server,shell-completions)
                 cmd="reactive__graph__server__shell__completions"
                 ;;
+            reactive__graph__server__graphql__schema,dynamic-graph-schema)
+                cmd="reactive__graph__server__graphql__schema__dynamic__graph__schema"
+                ;;
+            reactive__graph__server__graphql__schema,help)
+                cmd="reactive__graph__server__graphql__schema__help"
+                ;;
+            reactive__graph__server__graphql__schema,reactive-graph-plugin-schema)
+                cmd="reactive__graph__server__graphql__schema__reactive__graph__plugin__schema"
+                ;;
+            reactive__graph__server__graphql__schema,reactive-graph-runtime-schema)
+                cmd="reactive__graph__server__graphql__schema__reactive__graph__runtime__schema"
+                ;;
+            reactive__graph__server__graphql__schema,reactive-graph-schema)
+                cmd="reactive__graph__server__graphql__schema__reactive__graph__schema"
+                ;;
+            reactive__graph__server__graphql__schema__help,dynamic-graph-schema)
+                cmd="reactive__graph__server__graphql__schema__help__dynamic__graph__schema"
+                ;;
+            reactive__graph__server__graphql__schema__help,help)
+                cmd="reactive__graph__server__graphql__schema__help__help"
+                ;;
+            reactive__graph__server__graphql__schema__help,reactive-graph-plugin-schema)
+                cmd="reactive__graph__server__graphql__schema__help__reactive__graph__plugin__schema"
+                ;;
+            reactive__graph__server__graphql__schema__help,reactive-graph-runtime-schema)
+                cmd="reactive__graph__server__graphql__schema__help__reactive__graph__runtime__schema"
+                ;;
+            reactive__graph__server__graphql__schema__help,reactive-graph-schema)
+                cmd="reactive__graph__server__graphql__schema__help__reactive__graph__schema"
+                ;;
             reactive__graph__server__help,daemon)
                 cmd="reactive__graph__server__help__daemon"
+                ;;
+            reactive__graph__server__help,graphql-schema)
+                cmd="reactive__graph__server__help__graphql__schema"
                 ;;
             reactive__graph__server__help,help)
                 cmd="reactive__graph__server__help__help"
@@ -46,17 +82,56 @@ _reactive-graph-server() {
             reactive__graph__server__help,info)
                 cmd="reactive__graph__server__help__info"
                 ;;
+            reactive__graph__server__help,json-schema)
+                cmd="reactive__graph__server__help__json__schema"
+                ;;
             reactive__graph__server__help,man-pages)
                 cmd="reactive__graph__server__help__man__pages"
                 ;;
             reactive__graph__server__help,print-markdown-help)
                 cmd="reactive__graph__server__help__print__markdown__help"
                 ;;
-            reactive__graph__server__help,schema)
-                cmd="reactive__graph__server__help__schema"
-                ;;
             reactive__graph__server__help,shell-completions)
                 cmd="reactive__graph__server__help__shell__completions"
+                ;;
+            reactive__graph__server__help__graphql__schema,dynamic-graph-schema)
+                cmd="reactive__graph__server__help__graphql__schema__dynamic__graph__schema"
+                ;;
+            reactive__graph__server__help__graphql__schema,reactive-graph-plugin-schema)
+                cmd="reactive__graph__server__help__graphql__schema__reactive__graph__plugin__schema"
+                ;;
+            reactive__graph__server__help__graphql__schema,reactive-graph-runtime-schema)
+                cmd="reactive__graph__server__help__graphql__schema__reactive__graph__runtime__schema"
+                ;;
+            reactive__graph__server__help__graphql__schema,reactive-graph-schema)
+                cmd="reactive__graph__server__help__graphql__schema__reactive__graph__schema"
+                ;;
+            reactive__graph__server__help__json__schema,instances)
+                cmd="reactive__graph__server__help__json__schema__instances"
+                ;;
+            reactive__graph__server__help__json__schema,types)
+                cmd="reactive__graph__server__help__json__schema__types"
+                ;;
+            reactive__graph__server__help__json__schema__instances,entities)
+                cmd="reactive__graph__server__help__json__schema__instances__entities"
+                ;;
+            reactive__graph__server__help__json__schema__instances,flows)
+                cmd="reactive__graph__server__help__json__schema__instances__flows"
+                ;;
+            reactive__graph__server__help__json__schema__instances,relations)
+                cmd="reactive__graph__server__help__json__schema__instances__relations"
+                ;;
+            reactive__graph__server__help__json__schema__types,components)
+                cmd="reactive__graph__server__help__json__schema__types__components"
+                ;;
+            reactive__graph__server__help__json__schema__types,entities)
+                cmd="reactive__graph__server__help__json__schema__types__entities"
+                ;;
+            reactive__graph__server__help__json__schema__types,flows)
+                cmd="reactive__graph__server__help__json__schema__types__flows"
+                ;;
+            reactive__graph__server__help__json__schema__types,relations)
+                cmd="reactive__graph__server__help__json__schema__types__relations"
                 ;;
             reactive__graph__server__help__man__pages,install)
                 cmd="reactive__graph__server__help__man__pages__install"
@@ -64,23 +139,104 @@ _reactive-graph-server() {
             reactive__graph__server__help__man__pages,print)
                 cmd="reactive__graph__server__help__man__pages__print"
                 ;;
-            reactive__graph__server__help__schema,dynamic-graph-schema)
-                cmd="reactive__graph__server__help__schema__dynamic__graph__schema"
-                ;;
-            reactive__graph__server__help__schema,reactive-graph-plugin-schema)
-                cmd="reactive__graph__server__help__schema__reactive__graph__plugin__schema"
-                ;;
-            reactive__graph__server__help__schema,reactive-graph-runtime-schema)
-                cmd="reactive__graph__server__help__schema__reactive__graph__runtime__schema"
-                ;;
-            reactive__graph__server__help__schema,reactive-graph-schema)
-                cmd="reactive__graph__server__help__schema__reactive__graph__schema"
-                ;;
             reactive__graph__server__help__shell__completions,install)
                 cmd="reactive__graph__server__help__shell__completions__install"
                 ;;
             reactive__graph__server__help__shell__completions,print)
                 cmd="reactive__graph__server__help__shell__completions__print"
+                ;;
+            reactive__graph__server__json__schema,help)
+                cmd="reactive__graph__server__json__schema__help"
+                ;;
+            reactive__graph__server__json__schema,instances)
+                cmd="reactive__graph__server__json__schema__instances"
+                ;;
+            reactive__graph__server__json__schema,types)
+                cmd="reactive__graph__server__json__schema__types"
+                ;;
+            reactive__graph__server__json__schema__help,help)
+                cmd="reactive__graph__server__json__schema__help__help"
+                ;;
+            reactive__graph__server__json__schema__help,instances)
+                cmd="reactive__graph__server__json__schema__help__instances"
+                ;;
+            reactive__graph__server__json__schema__help,types)
+                cmd="reactive__graph__server__json__schema__help__types"
+                ;;
+            reactive__graph__server__json__schema__help__instances,entities)
+                cmd="reactive__graph__server__json__schema__help__instances__entities"
+                ;;
+            reactive__graph__server__json__schema__help__instances,flows)
+                cmd="reactive__graph__server__json__schema__help__instances__flows"
+                ;;
+            reactive__graph__server__json__schema__help__instances,relations)
+                cmd="reactive__graph__server__json__schema__help__instances__relations"
+                ;;
+            reactive__graph__server__json__schema__help__types,components)
+                cmd="reactive__graph__server__json__schema__help__types__components"
+                ;;
+            reactive__graph__server__json__schema__help__types,entities)
+                cmd="reactive__graph__server__json__schema__help__types__entities"
+                ;;
+            reactive__graph__server__json__schema__help__types,flows)
+                cmd="reactive__graph__server__json__schema__help__types__flows"
+                ;;
+            reactive__graph__server__json__schema__help__types,relations)
+                cmd="reactive__graph__server__json__schema__help__types__relations"
+                ;;
+            reactive__graph__server__json__schema__instances,entities)
+                cmd="reactive__graph__server__json__schema__instances__entities"
+                ;;
+            reactive__graph__server__json__schema__instances,flows)
+                cmd="reactive__graph__server__json__schema__instances__flows"
+                ;;
+            reactive__graph__server__json__schema__instances,help)
+                cmd="reactive__graph__server__json__schema__instances__help"
+                ;;
+            reactive__graph__server__json__schema__instances,relations)
+                cmd="reactive__graph__server__json__schema__instances__relations"
+                ;;
+            reactive__graph__server__json__schema__instances__help,entities)
+                cmd="reactive__graph__server__json__schema__instances__help__entities"
+                ;;
+            reactive__graph__server__json__schema__instances__help,flows)
+                cmd="reactive__graph__server__json__schema__instances__help__flows"
+                ;;
+            reactive__graph__server__json__schema__instances__help,help)
+                cmd="reactive__graph__server__json__schema__instances__help__help"
+                ;;
+            reactive__graph__server__json__schema__instances__help,relations)
+                cmd="reactive__graph__server__json__schema__instances__help__relations"
+                ;;
+            reactive__graph__server__json__schema__types,components)
+                cmd="reactive__graph__server__json__schema__types__components"
+                ;;
+            reactive__graph__server__json__schema__types,entities)
+                cmd="reactive__graph__server__json__schema__types__entities"
+                ;;
+            reactive__graph__server__json__schema__types,flows)
+                cmd="reactive__graph__server__json__schema__types__flows"
+                ;;
+            reactive__graph__server__json__schema__types,help)
+                cmd="reactive__graph__server__json__schema__types__help"
+                ;;
+            reactive__graph__server__json__schema__types,relations)
+                cmd="reactive__graph__server__json__schema__types__relations"
+                ;;
+            reactive__graph__server__json__schema__types__help,components)
+                cmd="reactive__graph__server__json__schema__types__help__components"
+                ;;
+            reactive__graph__server__json__schema__types__help,entities)
+                cmd="reactive__graph__server__json__schema__types__help__entities"
+                ;;
+            reactive__graph__server__json__schema__types__help,flows)
+                cmd="reactive__graph__server__json__schema__types__help__flows"
+                ;;
+            reactive__graph__server__json__schema__types__help,help)
+                cmd="reactive__graph__server__json__schema__types__help__help"
+                ;;
+            reactive__graph__server__json__schema__types__help,relations)
+                cmd="reactive__graph__server__json__schema__types__help__relations"
                 ;;
             reactive__graph__server__man__pages,help)
                 cmd="reactive__graph__server__man__pages__help"
@@ -99,36 +255,6 @@ _reactive-graph-server() {
                 ;;
             reactive__graph__server__man__pages__help,print)
                 cmd="reactive__graph__server__man__pages__help__print"
-                ;;
-            reactive__graph__server__schema,dynamic-graph-schema)
-                cmd="reactive__graph__server__schema__dynamic__graph__schema"
-                ;;
-            reactive__graph__server__schema,help)
-                cmd="reactive__graph__server__schema__help"
-                ;;
-            reactive__graph__server__schema,reactive-graph-plugin-schema)
-                cmd="reactive__graph__server__schema__reactive__graph__plugin__schema"
-                ;;
-            reactive__graph__server__schema,reactive-graph-runtime-schema)
-                cmd="reactive__graph__server__schema__reactive__graph__runtime__schema"
-                ;;
-            reactive__graph__server__schema,reactive-graph-schema)
-                cmd="reactive__graph__server__schema__reactive__graph__schema"
-                ;;
-            reactive__graph__server__schema__help,dynamic-graph-schema)
-                cmd="reactive__graph__server__schema__help__dynamic__graph__schema"
-                ;;
-            reactive__graph__server__schema__help,help)
-                cmd="reactive__graph__server__schema__help__help"
-                ;;
-            reactive__graph__server__schema__help,reactive-graph-plugin-schema)
-                cmd="reactive__graph__server__schema__help__reactive__graph__plugin__schema"
-                ;;
-            reactive__graph__server__schema__help,reactive-graph-runtime-schema)
-                cmd="reactive__graph__server__schema__help__reactive__graph__runtime__schema"
-                ;;
-            reactive__graph__server__schema__help,reactive-graph-schema)
-                cmd="reactive__graph__server__schema__help__reactive__graph__schema"
                 ;;
             reactive__graph__server__shell__completions,help)
                 cmd="reactive__graph__server__shell__completions__help"
@@ -155,7 +281,7 @@ _reactive-graph-server() {
 
     case "${cmd}" in
         reactive__graph__server)
-            opts="-n -d -w -c -x -p -P -q -h -V --logging-config --instance-config --graphql-config --plugins-config --instance-name --instance-description --hostname --port --secure --ssl-certificate-path --ssl-private-key-path --shutdown-timeout --workers --default-context-path --disable-all-plugins --disabled-plugins --enabled-plugins --disable-hot-deploy --hot-deploy-location --install-location --stop-immediately --quiet --help --version shell-completions man-pages print-markdown-help info daemon schema help"
+            opts="-n -d -w -c -x -p -P -q -h -V --logging-config --instance-config --graphql-config --plugins-config --instance-name --instance-description --hostname --port --secure --ssl-certificate-path --ssl-private-key-path --shutdown-timeout --workers --default-context-path --disable-all-plugins --disabled-plugins --enabled-plugins --disable-hot-deploy --hot-deploy-location --install-location --stop-immediately --quiet --help --version shell-completions man-pages print-markdown-help info daemon graphql-schema json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -330,8 +456,162 @@ _reactive-graph-server() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        reactive__graph__server__graphql__schema)
+            opts="-h -V --help --version reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__dynamic__graph__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__help)
+            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__help__dynamic__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__help__reactive__graph__plugin__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__help__reactive__graph__runtime__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__help__reactive__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__reactive__graph__plugin__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__reactive__graph__runtime__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__graphql__schema__reactive__graph__schema)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         reactive__graph__server__help)
-            opts="shell-completions man-pages print-markdown-help info daemon schema help"
+            opts="shell-completions man-pages print-markdown-help info daemon graphql-schema json-schema help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -347,6 +627,76 @@ _reactive-graph-server() {
         reactive__graph__server__help__daemon)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__graphql__schema)
+            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__graphql__schema__dynamic__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__graphql__schema__reactive__graph__plugin__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__graphql__schema__reactive__graph__runtime__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__graphql__schema__reactive__graph__schema)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -375,6 +725,146 @@ _reactive-graph-server() {
         reactive__graph__server__help__info)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema)
+            opts="types instances"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__instances)
+            opts="entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__instances__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__instances__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__instances__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__types)
+            opts="components entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__types__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__types__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__types__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__help__json__schema__types__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -442,76 +932,6 @@ _reactive-graph-server() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        reactive__graph__server__help__schema)
-            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__help__schema__dynamic__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__help__schema__reactive__graph__plugin__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__help__schema__reactive__graph__runtime__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__help__schema__reactive__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
         reactive__graph__server__help__shell__completions)
             opts="print install"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -565,6 +985,454 @@ _reactive-graph-server() {
                     COMPREPLY=($(compgen -W "table html-table markdown-table count json json5 toml" -- "${cur}"))
                     return 0
                     ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema)
+            opts="-h -V --help --version types instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help)
+            opts="types instances help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__instances)
+            opts="entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__instances__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__instances__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__instances__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__types)
+            opts="components entities relations flows"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__types__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__types__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__types__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__help__types__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances)
+            opts="-h -V --help --version entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__entities)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__flows)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__help)
+            opts="entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__help__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__help__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__help__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__instances__relations)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types)
+            opts="-h -V --help --version components entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__components)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__entities)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__flows)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__help)
+            opts="components entities relations flows help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__help__components)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__help__entities)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__help__flows)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__help__relations)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        reactive__graph__server__json__schema__types__relations)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 *)
                     COMPREPLY=()
                     ;;
@@ -673,160 +1541,6 @@ _reactive-graph-server() {
         reactive__graph__server__print__markdown__help)
             opts="-h -V --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema)
-            opts="-h -V --help --version reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__dynamic__graph__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__help)
-            opts="reactive-graph-schema dynamic-graph-schema reactive-graph-plugin-schema reactive-graph-runtime-schema help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__help__dynamic__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__help__help)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__help__reactive__graph__plugin__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__help__reactive__graph__runtime__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__help__reactive__graph__schema)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__reactive__graph__plugin__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__reactive__graph__runtime__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        reactive__graph__server__schema__reactive__graph__schema)
-            opts="-h -V --help --version"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph-client.1
+++ b/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph-client.1
@@ -4,44 +4,66 @@
 .SH NAME
 reactive\-graph\-client \- Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 .SH SYNOPSIS
-\fBreactive\-graph\-client\fR [\fB\-\-client\-hostname\fR] [\fB\-\-client\-port\fR] [\fB\-\-client\-secure\fR] [\fB\-\-endpoint\-graphql\fR] [\fB\-\-endpoint\-dynamic\-graph\fR] [\fB\-\-endpoint\-runtime\fR] [\fB\-\-endpoint\-plugins\fR] [\fB\-\-bearer\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBreactive\-graph\-client\fR [\fB\-\-client\-hostname\fR] [\fB\-\-client\-port\fR] [\fB\-\-client\-secure\fR] [\fB\-\-endpoint\-graphql\fR] [\fB\-\-endpoint\-dynamic\-graph\fR] [\fB\-\-endpoint\-runtime\fR] [\fB\-\-endpoint\-plugins\fR] [\fB\-\-bearer\fR] [\fB\-\-danger\-accept\-invalid\-certs\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIDANGER_ACCEPT_INVALID_HOSTNAMES\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 .SH OPTIONS
 .TP
-\fB\-\-client\-hostname\fR=\fICLIENT_HOSTNAME\fR
+\fB\-\-client\-hostname\fR \fI<CLIENT_HOSTNAME>\fR
 The hostname to connect to
 .TP
-\fB\-\-client\-port\fR=\fICLIENT_PORT\fR
+\fB\-\-client\-port\fR \fI<CLIENT_PORT>\fR
 The port to connect to
 .TP
-\fB\-\-client\-secure\fR=\fICLIENT_SECURE\fR
+\fB\-\-client\-secure\fR \fI<CLIENT_SECURE>\fR
 If true, connects via HTTPS
 .br
 
 .br
 [\fIpossible values: \fRtrue, false]
 .TP
-\fB\-\-endpoint\-graphql\fR=\fIENDPOINT_GRAPHQL\fR
+\fB\-\-endpoint\-graphql\fR \fI<ENDPOINT_GRAPHQL>\fR
 The endpoint to use
 .TP
-\fB\-\-endpoint\-dynamic\-graph\fR=\fIENDPOINT_DYNAMIC_GRAPH\fR
+\fB\-\-endpoint\-dynamic\-graph\fR \fI<ENDPOINT_DYNAMIC_GRAPH>\fR
 The endpoint to use
 .TP
-\fB\-\-endpoint\-runtime\fR=\fIENDPOINT_RUNTIME\fR
+\fB\-\-endpoint\-runtime\fR \fI<ENDPOINT_RUNTIME>\fR
 The endpoint to use
 .TP
-\fB\-\-endpoint\-plugins\fR=\fIENDPOINT_PLUGINS\fR
+\fB\-\-endpoint\-plugins\fR \fI<ENDPOINT_PLUGINS>\fR
 The endpoint to use
 .TP
-\fB\-\-bearer\fR=\fIBEARER\fR
+\fB\-\-bearer\fR \fI<BEARER>\fR
 The authentication token
 .TP
+\fB\-\-danger\-accept\-invalid\-certs\fR \fI<DANGER_ACCEPT_INVALID_CERTS>\fR
+Controls the use of certificate validation.
+
+Defaults to `false`.
+
+Warning: You should think very carefully before using this method. If invalid certificates are trusted, *any* certificate for *any* site will be trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print version
+.TP
+[\fIDANGER_ACCEPT_INVALID_HOSTNAMES\fR]
+Controls the use of hostname verification.
+
+Defaults to `false`.
+
+Warning: You should think very carefully before you use this method. If hostname verification is not used, any valid certificate for any site will be trusted for use from any other. This introduces a significant vulnerability to man\-in\-the\-middle attacks.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
 .SH SUBCOMMANDS
 .TP
 reactive\-graph\-client\-shell\-completions(1)
@@ -91,6 +113,9 @@ Manage relation instances
 .TP
 reactive\-graph\-client\-flow\-instances(1)
 Manage flow instances
+.TP
+reactive\-graph\-client\-introspection(1)
+Execute GraphQL introspection queries
 .TP
 reactive\-graph\-client\-help(1)
 Print this message or the help of the given subcommand(s)

--- a/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph-server.1
+++ b/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph-server.1
@@ -9,55 +9,55 @@ reactive\-graph\-server \- Reactive Graph is a reactive runtime based on a graph
 Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 .SH OPTIONS
 .TP
-\fB\-\-logging\-config\fR=\fILOGGING_CONFIG\fR
+\fB\-\-logging\-config\fR \fI<LOGGING_CONFIG>\fR
 The logging config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_LOGGING_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-\-instance\-config\fR=\fIINSTANCE_CONFIG\fR
+\fB\-\-instance\-config\fR \fI<INSTANCE_CONFIG>\fR
 The instance config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-\-graphql\-config\fR=\fIGRAPHQL_CONFIG\fR
+\fB\-\-graphql\-config\fR \fI<GRAPHQL_CONFIG>\fR
 The GraphQL config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_GRAPHQL_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-\-plugins\-config\fR=\fIPLUGINS_CONFIG\fR
+\fB\-\-plugins\-config\fR \fI<PLUGINS_CONFIG>\fR
 The plugins config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_PLUGINS_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-n\fR, \fB\-\-instance\-name\fR=\fINAME\fR
+\fB\-n\fR, \fB\-\-instance\-name\fR \fI<NAME>\fR
 The name of the instance
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_NAME\fR environment variable. 
 .RE
 .TP
-\fB\-d\fR, \fB\-\-instance\-description\fR=\fIDESCRIPTION\fR
+\fB\-d\fR, \fB\-\-instance\-description\fR \fI<DESCRIPTION>\fR
 The description of the instance
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_DESCRIPTION\fR environment variable. 
 .RE
 .TP
-\fB\-\-hostname\fR=\fIHOSTNAME\fR
+\fB\-\-hostname\fR \fI<HOSTNAME>\fR
 The hostname to bind the GraphQL HTTP server
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_HOSTNAME\fR environment variable. 
 .RE
 .TP
-\fB\-\-port\fR=\fIPORT\fR
+\fB\-\-port\fR \fI<PORT>\fR
 The port to bind the GraphQL HTTP server
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_PORT\fR environment variable. 
 .RE
 .TP
-\fB\-\-secure\fR=\fISECURE\fR
+\fB\-\-secure\fR \fI<SECURE>\fR
 If true, HTTPS is enabled
 .br
 
@@ -67,37 +67,37 @@ If true, HTTPS is enabled
 May also be specified with the \fBREACTIVE_GRAPH_SECURE\fR environment variable. 
 .RE
 .TP
-\fB\-\-ssl\-certificate\-path\fR=\fISSL_CERTIFICATE_PATH\fR
+\fB\-\-ssl\-certificate\-path\fR \fI<SSL_CERTIFICATE_PATH>\fR
 The location of the certificate
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_SSL_CERTIFICATE_PATH\fR environment variable. 
 .RE
 .TP
-\fB\-\-ssl\-private\-key\-path\fR=\fISSL_PRIVATE_KEY_PATH\fR
+\fB\-\-ssl\-private\-key\-path\fR \fI<SSL_PRIVATE_KEY_PATH>\fR
 The location of the private key
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_SSL_PRIVATE_KEY_PATH\fR environment variable. 
 .RE
 .TP
-\fB\-\-shutdown\-timeout\fR=\fISHUTDOWN_TIMEOUT\fR
+\fB\-\-shutdown\-timeout\fR \fI<SHUTDOWN_TIMEOUT>\fR
 Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_SHUTDOWN_TIMEOUT\fR environment variable. 
 .RE
 .TP
-\fB\-w\fR, \fB\-\-workers\fR=\fIWORKERS\fR
+\fB\-w\fR, \fB\-\-workers\fR \fI<WORKERS>\fR
 The number of workers to start. The default worker count is the number of physical CPU cores available
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_WORKERS\fR environment variable. 
 .RE
 .TP
-\fB\-c\fR, \fB\-\-default\-context\-path\fR=\fIDEFAULT_CONTEXT_PATH\fR
+\fB\-c\fR, \fB\-\-default\-context\-path\fR \fI<DEFAULT_CONTEXT_PATH>\fR
 The default context path which redirects the root context to a web resource provider
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_DEFAULT_CONTEXT_PATH\fR environment variable. 
 .RE
 .TP
-\fB\-x\fR, \fB\-\-disable\-all\-plugins\fR=\fIDISABLE_ALL_PLUGINS\fR
+\fB\-x\fR, \fB\-\-disable\-all\-plugins\fR \fI<DISABLE_ALL_PLUGINS>\fR
 If true, all plugins will be disabled
 .br
 
@@ -107,13 +107,13 @@ If true, all plugins will be disabled
 May also be specified with the \fBREACTIVE_GRAPH_DISABLE_ALL_PLUGINS\fR environment variable. 
 .RE
 .TP
-\fB\-p\fR, \fB\-\-disabled\-plugins\fR=\fIDISABLED_PLUGINS\fR
+\fB\-p\fR, \fB\-\-disabled\-plugins\fR \fI<DISABLED_PLUGINS>\fR
 The list of plugins to disable
 .TP
-\fB\-P\fR, \fB\-\-enabled\-plugins\fR=\fIENABLED_PLUGINS\fR
+\fB\-P\fR, \fB\-\-enabled\-plugins\fR \fI<ENABLED_PLUGINS>\fR
 The list of plugins to enable
 .TP
-\fB\-\-disable\-hot\-deploy\fR=\fIDISABLE_HOT_DEPLOY\fR
+\fB\-\-disable\-hot\-deploy\fR \fI<DISABLE_HOT_DEPLOY>\fR
 If true, hot deployment will be disabled
 .br
 
@@ -123,19 +123,19 @@ If true, hot deployment will be disabled
 May also be specified with the \fBREACTIVE_GRAPH_DISABLE_HOT_DEPLOY\fR environment variable. 
 .RE
 .TP
-\fB\-\-hot\-deploy\-location\fR=\fIHOT_DEPLOY_LOCATION\fR
+\fB\-\-hot\-deploy\-location\fR \fI<HOT_DEPLOY_LOCATION>\fR
 The folder which is watched for hot deployment
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_HOT_DEPLOY_LOCATION\fR environment variable. 
 .RE
 .TP
-\fB\-\-install\-location\fR=\fIINSTALL_LOCATION\fR
+\fB\-\-install\-location\fR \fI<INSTALL_LOCATION>\fR
 The folder which plugins are installed permanently
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTALL_LOCATION\fR environment variable. 
 .RE
 .TP
-\fB\-\-stop\-immediately\fR=\fISTOP_IMMEDIATELY\fR
+\fB\-\-stop\-immediately\fR \fI<STOP_IMMEDIATELY>\fR
 If true, the runtime does not wait before exiting
 .br
 
@@ -145,7 +145,7 @@ If true, the runtime does not wait before exiting
 May also be specified with the \fBREACTIVE_GRAPH_STOP_IMMEDIATELY\fR environment variable. 
 .RE
 .TP
-\fB\-q\fR, \fB\-\-quiet\fR=\fIQUIET\fR
+\fB\-q\fR, \fB\-\-quiet\fR \fI<QUIET>\fR
 If true, logging is disabled completely
 .br
 
@@ -177,8 +177,11 @@ Prints info about this binary
 reactive\-graph\-server\-daemon(1)
 Runs the server as daemon
 .TP
-reactive\-graph\-server\-schema(1)
+reactive\-graph\-server\-graphql\-schema(1)
 Prints the GraphQL schema and exits
+.TP
+reactive\-graph\-server\-json\-schema(1)
+Prints the JSON schema and exits
 .TP
 reactive\-graph\-server\-help(1)
 Print this message or the help of the given subcommand(s)

--- a/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph.1
+++ b/crates/reactive-graph/debian/usr/share/man/man1/reactive-graph.1
@@ -4,60 +4,60 @@
 .SH NAME
 reactive\-graph \- Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 .SH SYNOPSIS
-\fBreactive\-graph\fR [\fB\-\-logging\-config\fR] [\fB\-\-instance\-config\fR] [\fB\-\-graphql\-config\fR] [\fB\-\-plugins\-config\fR] [\fB\-n\fR|\fB\-\-instance\-name\fR] [\fB\-d\fR|\fB\-\-instance\-description\fR] [\fB\-\-hostname\fR] [\fB\-\-port\fR] [\fB\-\-secure\fR] [\fB\-\-ssl\-certificate\-path\fR] [\fB\-\-ssl\-private\-key\-path\fR] [\fB\-\-shutdown\-timeout\fR] [\fB\-w\fR|\fB\-\-workers\fR] [\fB\-c\fR|\fB\-\-default\-context\-path\fR] [\fB\-x\fR|\fB\-\-disable\-all\-plugins\fR] [\fB\-p\fR|\fB\-\-disabled\-plugins\fR] [\fB\-P\fR|\fB\-\-enabled\-plugins\fR] [\fB\-\-disable\-hot\-deploy\fR] [\fB\-\-hot\-deploy\-location\fR] [\fB\-\-install\-location\fR] [\fB\-\-stop\-immediately\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-client\-hostname\fR] [\fB\-\-client\-port\fR] [\fB\-\-client\-secure\fR] [\fB\-\-endpoint\-graphql\fR] [\fB\-\-endpoint\-dynamic\-graph\fR] [\fB\-\-endpoint\-runtime\fR] [\fB\-\-endpoint\-plugins\fR] [\fB\-\-bearer\fR] [\fB\-i\fR|\fB\-\-interactive\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBreactive\-graph\fR [\fB\-\-logging\-config\fR] [\fB\-\-instance\-config\fR] [\fB\-\-graphql\-config\fR] [\fB\-\-plugins\-config\fR] [\fB\-n\fR|\fB\-\-instance\-name\fR] [\fB\-d\fR|\fB\-\-instance\-description\fR] [\fB\-\-hostname\fR] [\fB\-\-port\fR] [\fB\-\-secure\fR] [\fB\-\-ssl\-certificate\-path\fR] [\fB\-\-ssl\-private\-key\-path\fR] [\fB\-\-shutdown\-timeout\fR] [\fB\-w\fR|\fB\-\-workers\fR] [\fB\-c\fR|\fB\-\-default\-context\-path\fR] [\fB\-x\fR|\fB\-\-disable\-all\-plugins\fR] [\fB\-p\fR|\fB\-\-disabled\-plugins\fR] [\fB\-P\fR|\fB\-\-enabled\-plugins\fR] [\fB\-\-disable\-hot\-deploy\fR] [\fB\-\-hot\-deploy\-location\fR] [\fB\-\-install\-location\fR] [\fB\-\-stop\-immediately\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-client\-hostname\fR] [\fB\-\-client\-port\fR] [\fB\-\-client\-secure\fR] [\fB\-\-endpoint\-graphql\fR] [\fB\-\-endpoint\-dynamic\-graph\fR] [\fB\-\-endpoint\-runtime\fR] [\fB\-\-endpoint\-plugins\fR] [\fB\-\-bearer\fR] [\fB\-\-danger\-accept\-invalid\-certs\fR] [\fB\-i\fR|\fB\-\-interactive\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIDANGER_ACCEPT_INVALID_HOSTNAMES\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 .SH OPTIONS
 .TP
-\fB\-\-logging\-config\fR=\fILOGGING_CONFIG\fR
+\fB\-\-logging\-config\fR \fI<LOGGING_CONFIG>\fR
 The logging config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_LOGGING_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-\-instance\-config\fR=\fIINSTANCE_CONFIG\fR
+\fB\-\-instance\-config\fR \fI<INSTANCE_CONFIG>\fR
 The instance config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-\-graphql\-config\fR=\fIGRAPHQL_CONFIG\fR
+\fB\-\-graphql\-config\fR \fI<GRAPHQL_CONFIG>\fR
 The GraphQL config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_GRAPHQL_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-\-plugins\-config\fR=\fIPLUGINS_CONFIG\fR
+\fB\-\-plugins\-config\fR \fI<PLUGINS_CONFIG>\fR
 The plugins config location
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_PLUGINS_CONFIG\fR environment variable. 
 .RE
 .TP
-\fB\-n\fR, \fB\-\-instance\-name\fR=\fINAME\fR
+\fB\-n\fR, \fB\-\-instance\-name\fR \fI<NAME>\fR
 The name of the instance
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_NAME\fR environment variable. 
 .RE
 .TP
-\fB\-d\fR, \fB\-\-instance\-description\fR=\fIDESCRIPTION\fR
+\fB\-d\fR, \fB\-\-instance\-description\fR \fI<DESCRIPTION>\fR
 The description of the instance
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_DESCRIPTION\fR environment variable. 
 .RE
 .TP
-\fB\-\-hostname\fR=\fIHOSTNAME\fR
+\fB\-\-hostname\fR \fI<HOSTNAME>\fR
 The hostname to bind the GraphQL HTTP server
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_HOSTNAME\fR environment variable. 
 .RE
 .TP
-\fB\-\-port\fR=\fIPORT\fR
+\fB\-\-port\fR \fI<PORT>\fR
 The port to bind the GraphQL HTTP server
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_PORT\fR environment variable. 
 .RE
 .TP
-\fB\-\-secure\fR=\fISECURE\fR
+\fB\-\-secure\fR \fI<SECURE>\fR
 If true, HTTPS is enabled
 .br
 
@@ -67,37 +67,37 @@ If true, HTTPS is enabled
 May also be specified with the \fBREACTIVE_GRAPH_SECURE\fR environment variable. 
 .RE
 .TP
-\fB\-\-ssl\-certificate\-path\fR=\fISSL_CERTIFICATE_PATH\fR
+\fB\-\-ssl\-certificate\-path\fR \fI<SSL_CERTIFICATE_PATH>\fR
 The location of the certificate
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_SSL_CERTIFICATE_PATH\fR environment variable. 
 .RE
 .TP
-\fB\-\-ssl\-private\-key\-path\fR=\fISSL_PRIVATE_KEY_PATH\fR
+\fB\-\-ssl\-private\-key\-path\fR \fI<SSL_PRIVATE_KEY_PATH>\fR
 The location of the private key
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_SSL_PRIVATE_KEY_PATH\fR environment variable. 
 .RE
 .TP
-\fB\-\-shutdown\-timeout\fR=\fISHUTDOWN_TIMEOUT\fR
+\fB\-\-shutdown\-timeout\fR \fI<SHUTDOWN_TIMEOUT>\fR
 Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTANCE_SHUTDOWN_TIMEOUT\fR environment variable. 
 .RE
 .TP
-\fB\-w\fR, \fB\-\-workers\fR=\fIWORKERS\fR
+\fB\-w\fR, \fB\-\-workers\fR \fI<WORKERS>\fR
 The number of workers to start. The default worker count is the number of physical CPU cores available
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_WORKERS\fR environment variable. 
 .RE
 .TP
-\fB\-c\fR, \fB\-\-default\-context\-path\fR=\fIDEFAULT_CONTEXT_PATH\fR
+\fB\-c\fR, \fB\-\-default\-context\-path\fR \fI<DEFAULT_CONTEXT_PATH>\fR
 The default context path which redirects the root context to a web resource provider
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_DEFAULT_CONTEXT_PATH\fR environment variable. 
 .RE
 .TP
-\fB\-x\fR, \fB\-\-disable\-all\-plugins\fR=\fIDISABLE_ALL_PLUGINS\fR
+\fB\-x\fR, \fB\-\-disable\-all\-plugins\fR \fI<DISABLE_ALL_PLUGINS>\fR
 If true, all plugins will be disabled
 .br
 
@@ -107,13 +107,13 @@ If true, all plugins will be disabled
 May also be specified with the \fBREACTIVE_GRAPH_DISABLE_ALL_PLUGINS\fR environment variable. 
 .RE
 .TP
-\fB\-p\fR, \fB\-\-disabled\-plugins\fR=\fIDISABLED_PLUGINS\fR
+\fB\-p\fR, \fB\-\-disabled\-plugins\fR \fI<DISABLED_PLUGINS>\fR
 The list of plugins to disable
 .TP
-\fB\-P\fR, \fB\-\-enabled\-plugins\fR=\fIENABLED_PLUGINS\fR
+\fB\-P\fR, \fB\-\-enabled\-plugins\fR \fI<ENABLED_PLUGINS>\fR
 The list of plugins to enable
 .TP
-\fB\-\-disable\-hot\-deploy\fR=\fIDISABLE_HOT_DEPLOY\fR
+\fB\-\-disable\-hot\-deploy\fR \fI<DISABLE_HOT_DEPLOY>\fR
 If true, hot deployment will be disabled
 .br
 
@@ -123,19 +123,19 @@ If true, hot deployment will be disabled
 May also be specified with the \fBREACTIVE_GRAPH_DISABLE_HOT_DEPLOY\fR environment variable. 
 .RE
 .TP
-\fB\-\-hot\-deploy\-location\fR=\fIHOT_DEPLOY_LOCATION\fR
+\fB\-\-hot\-deploy\-location\fR \fI<HOT_DEPLOY_LOCATION>\fR
 The folder which is watched for hot deployment
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_HOT_DEPLOY_LOCATION\fR environment variable. 
 .RE
 .TP
-\fB\-\-install\-location\fR=\fIINSTALL_LOCATION\fR
+\fB\-\-install\-location\fR \fI<INSTALL_LOCATION>\fR
 The folder which plugins are installed permanently
 .RS
 May also be specified with the \fBREACTIVE_GRAPH_INSTALL_LOCATION\fR environment variable. 
 .RE
 .TP
-\fB\-\-stop\-immediately\fR=\fISTOP_IMMEDIATELY\fR
+\fB\-\-stop\-immediately\fR \fI<STOP_IMMEDIATELY>\fR
 If true, the runtime does not wait before exiting
 .br
 
@@ -145,7 +145,7 @@ If true, the runtime does not wait before exiting
 May also be specified with the \fBREACTIVE_GRAPH_STOP_IMMEDIATELY\fR environment variable. 
 .RE
 .TP
-\fB\-q\fR, \fB\-\-quiet\fR=\fIQUIET\fR
+\fB\-q\fR, \fB\-\-quiet\fR \fI<QUIET>\fR
 If true, logging is disabled completely
 .br
 
@@ -155,42 +155,64 @@ If true, logging is disabled completely
 May also be specified with the \fBREACTIVE_GRAPH_QUIET\fR environment variable. 
 .RE
 .TP
-\fB\-\-client\-hostname\fR=\fICLIENT_HOSTNAME\fR
+\fB\-\-client\-hostname\fR \fI<CLIENT_HOSTNAME>\fR
 The hostname to connect to
 .TP
-\fB\-\-client\-port\fR=\fICLIENT_PORT\fR
+\fB\-\-client\-port\fR \fI<CLIENT_PORT>\fR
 The port to connect to
 .TP
-\fB\-\-client\-secure\fR=\fICLIENT_SECURE\fR
+\fB\-\-client\-secure\fR \fI<CLIENT_SECURE>\fR
 If true, connects via HTTPS
 .br
 
 .br
 [\fIpossible values: \fRtrue, false]
 .TP
-\fB\-\-endpoint\-graphql\fR=\fIENDPOINT_GRAPHQL\fR
+\fB\-\-endpoint\-graphql\fR \fI<ENDPOINT_GRAPHQL>\fR
 The endpoint to use
 .TP
-\fB\-\-endpoint\-dynamic\-graph\fR=\fIENDPOINT_DYNAMIC_GRAPH\fR
+\fB\-\-endpoint\-dynamic\-graph\fR \fI<ENDPOINT_DYNAMIC_GRAPH>\fR
 The endpoint to use
 .TP
-\fB\-\-endpoint\-runtime\fR=\fIENDPOINT_RUNTIME\fR
+\fB\-\-endpoint\-runtime\fR \fI<ENDPOINT_RUNTIME>\fR
 The endpoint to use
 .TP
-\fB\-\-endpoint\-plugins\fR=\fIENDPOINT_PLUGINS\fR
+\fB\-\-endpoint\-plugins\fR \fI<ENDPOINT_PLUGINS>\fR
 The endpoint to use
 .TP
-\fB\-\-bearer\fR=\fIBEARER\fR
+\fB\-\-bearer\fR \fI<BEARER>\fR
 The authentication token
+.TP
+\fB\-\-danger\-accept\-invalid\-certs\fR \fI<DANGER_ACCEPT_INVALID_CERTS>\fR
+Controls the use of certificate validation.
+
+Defaults to `false`.
+
+Warning: You should think very carefully before using this method. If invalid certificates are trusted, *any* certificate for *any* site will be trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
 .TP
 \fB\-i\fR, \fB\-\-interactive\fR
 Enter the interactive client mode
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print version
+.TP
+[\fIDANGER_ACCEPT_INVALID_HOSTNAMES\fR]
+Controls the use of hostname verification.
+
+Defaults to `false`.
+
+Warning: You should think very carefully before you use this method. If hostname verification is not used, any valid certificate for any site will be trusted for use from any other. This introduces a significant vulnerability to man\-in\-the\-middle attacks.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
 .SH SUBCOMMANDS
 .TP
 reactive\-graph\-shell\-completions(1)
@@ -208,8 +230,11 @@ Prints info about this binary
 reactive\-graph\-daemon(1)
 Runs the server as daemon
 .TP
-reactive\-graph\-schema(1)
+reactive\-graph\-graphql\-schema(1)
 Prints the GraphQL schema and exits
+.TP
+reactive\-graph\-json\-schema(1)
+Prints the JSON schema and exits
 .TP
 reactive\-graph\-execute\-command(1)
 Executes a command on the client
@@ -246,6 +271,9 @@ Manage relation instances
 .TP
 reactive\-graph\-flow\-instances(1)
 Manage flow instances
+.TP
+reactive\-graph\-introspection(1)
+Execute GraphQL introspection queries
 .TP
 reactive\-graph\-instances(1)
 Manage instances

--- a/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph
+++ b/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph
@@ -53,21 +53,23 @@ _reactive-graph() {
 '--endpoint-runtime=[The endpoint to use]:ENDPOINT_RUNTIME:_default' \
 '--endpoint-plugins=[The endpoint to use]:ENDPOINT_PLUGINS:_default' \
 '--bearer=[The authentication token]:BEARER:_default' \
+'--danger-accept-invalid-certs=[Controls the use of certificate validation]:DANGER_ACCEPT_INVALID_CERTS:(true false)' \
 '-i[Enter the interactive client mode]' \
 '--interactive[Enter the interactive client mode]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
+'::danger_accept_invalid_hostnames -- Controls the use of hostname verification:(true false)' \
 ":: :_reactive-graph_commands" \
 "*::: :->reactive-graph" \
 && ret=0
     case $state in
     (reactive-graph)
-        words=($line[1] "${words[@]}")
+        words=($line[2] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-command-$line[1]:"
-        case $line[1] in
+        curcontext="${curcontext%:*:*}:reactive-graph-command-$line[2]:"
+        case $line[2] in
             (shell-completions)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
@@ -230,21 +232,21 @@ _arguments "${_arguments_options[@]}" : \
 '--version[Print version]' \
 && ret=0
 ;;
-(schema)
+(graphql-schema)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_reactive-graph__schema_commands" \
-"*::: :->schema" \
+":: :_reactive-graph__graphql-schema_commands" \
+"*::: :->graphql-schema" \
 && ret=0
 
     case $state in
-    (schema)
+    (graphql-schema)
         words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-schema-command-$line[1]:"
+        curcontext="${curcontext%:*:*}:reactive-graph-graphql-schema-command-$line[1]:"
         case $line[1] in
             (reactive-graph-schema)
 _arguments "${_arguments_options[@]}" : \
@@ -280,7 +282,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_reactive-graph__schema__help_commands" \
+":: :_reactive-graph__graphql-schema__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -288,7 +290,7 @@ _arguments "${_arguments_options[@]}" : \
     (help)
         words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-schema-help-command-$line[1]:"
+        curcontext="${curcontext%:*:*}:reactive-graph-graphql-schema-help-command-$line[1]:"
         case $line[1] in
             (reactive-graph-schema)
 _arguments "${_arguments_options[@]}" : \
@@ -305,6 +307,270 @@ _arguments "${_arguments_options[@]}" : \
 (reactive-graph-runtime-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(json-schema)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__json-schema_commands" \
+"*::: :->json-schema" \
+&& ret=0
+
+    case $state in
+    (json-schema)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-command-$line[1]:"
+        case $line[1] in
+            (types)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__json-schema__types_commands" \
+"*::: :->types" \
+&& ret=0
+
+    case $state in
+    (types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-types-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__json-schema__types__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-types-help-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__json-schema__instances_commands" \
+"*::: :->instances" \
+&& ret=0
+
+    case $state in
+    (instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-instances-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__json-schema__instances__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-instances-help-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__json-schema__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-help-command-$line[1]:"
+        case $line[1] in
+            (types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__json-schema__help__types_commands" \
+"*::: :->types" \
+&& ret=0
+
+    case $state in
+    (types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-help-types-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__json-schema__help__instances_commands" \
+"*::: :->instances" \
+&& ret=0
+
+    case $state in
+    (instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-json-schema-help-instances-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
@@ -758,6 +1024,18 @@ _arguments "${_arguments_options[@]}" : \
 ':name -- The component name:_default' \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:_default' \
+':name -- The component name:_default' \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -894,6 +1172,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1003,6 +1285,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:_default' \
+':name -- The entity type name:_default' \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
 '--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -1182,6 +1476,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1299,6 +1597,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:_default' \
+':name -- The relation type name:_default' \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
 '--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -1482,6 +1792,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1587,6 +1901,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The flow type namespace:_default' \
+':name -- The flow type name:_default' \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
 '--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -1768,6 +2094,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -2565,6 +2895,94 @@ esac
     ;;
 esac
 ;;
+(introspection)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph__introspection_commands" \
+"*::: :->introspection" \
+&& ret=0
+
+    case $state in
+    (introspection)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-introspection-command-$line[1]:"
+        case $line[1] in
+            (reactive-graph)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(dynamic-graph)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(reactive-graph-runtime)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(reactive-graph-plugins)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__introspection__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-introspection-help-command-$line[1]:"
+        case $line[1] in
+            (reactive-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dynamic-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-runtime)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-plugins)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
 (instances)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
@@ -3095,17 +3513,17 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
-(schema)
+(graphql-schema)
 _arguments "${_arguments_options[@]}" : \
-":: :_reactive-graph__help__schema_commands" \
-"*::: :->schema" \
+":: :_reactive-graph__help__graphql-schema_commands" \
+"*::: :->graphql-schema" \
 && ret=0
 
     case $state in
-    (schema)
+    (graphql-schema)
         words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-help-schema-command-$line[1]:"
+        curcontext="${curcontext%:*:*}:reactive-graph-help-graphql-schema-command-$line[1]:"
         case $line[1] in
             (reactive-graph-schema)
 _arguments "${_arguments_options[@]}" : \
@@ -3122,6 +3540,82 @@ _arguments "${_arguments_options[@]}" : \
 (reactive-graph-runtime-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(json-schema)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__json-schema_commands" \
+"*::: :->json-schema" \
+&& ret=0
+
+    case $state in
+    (json-schema)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-json-schema-command-$line[1]:"
+        case $line[1] in
+            (types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__json-schema__types_commands" \
+"*::: :->types" \
+&& ret=0
+
+    case $state in
+    (types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-json-schema-types-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__json-schema__instances_commands" \
+"*::: :->instances" \
+&& ret=0
+
+    case $state in
+    (instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-json-schema-instances-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
         esac
     ;;
@@ -3283,6 +3777,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -3348,6 +3846,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -3427,6 +3929,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -3496,6 +4002,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -3723,6 +4233,38 @@ _arguments "${_arguments_options[@]}" : \
     ;;
 esac
 ;;
+(introspection)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph__help__introspection_commands" \
+"*::: :->introspection" \
+&& ret=0
+
+    case $state in
+    (introspection)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-help-introspection-command-$line[1]:"
+        case $line[1] in
+            (reactive-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dynamic-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-runtime)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-plugins)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
 (instances)
 _arguments "${_arguments_options[@]}" : \
 ":: :_reactive-graph__help__instances_commands" \
@@ -3868,7 +4410,8 @@ _reactive-graph_commands() {
 'print-markdown-help:Prints the markdown help to stdout' \
 'info:Prints info about this binary' \
 'daemon:Runs the server as daemon' \
-'schema:Prints the GraphQL schema and exits' \
+'graphql-schema:Prints the GraphQL schema and exits' \
+'json-schema:Prints the JSON schema and exits' \
 'execute-command:Executes a command on the client' \
 'instance-info:Prints information about the instance' \
 'plugins:Manage plugins' \
@@ -3881,6 +4424,7 @@ _reactive-graph_commands() {
 'entity-instances:Manage entity instances' \
 'relation-instances:Manage relation instances' \
 'flow-instances:Manage flow instances' \
+'introspection:Execute GraphQL introspection queries' \
 'instances:Manage instances' \
 'update:Update the Reactive Graph binary' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -3894,6 +4438,7 @@ _reactive-graph__components_commands() {
 'get:Prints a single component' \
 'list-properties:List the properties of a component' \
 'list-extensions:List the extensions of a component' \
+'get-json-schema:Prints the JSON Schema of a component' \
 'create:Creates a new component' \
 'delete:Deletes a component' \
 'add-property:Adds a property to a component' \
@@ -3931,6 +4476,11 @@ _reactive-graph__components__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph components get commands' commands "$@"
 }
+(( $+functions[_reactive-graph__components__get-json-schema_commands] )) ||
+_reactive-graph__components__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph components get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph__components__help_commands] )) ||
 _reactive-graph__components__help_commands() {
     local commands; commands=(
@@ -3938,6 +4488,7 @@ _reactive-graph__components__help_commands() {
 'get:Prints a single component' \
 'list-properties:List the properties of a component' \
 'list-extensions:List the extensions of a component' \
+'get-json-schema:Prints the JSON Schema of a component' \
 'create:Creates a new component' \
 'delete:Deletes a component' \
 'add-property:Adds a property to a component' \
@@ -3974,6 +4525,11 @@ _reactive-graph__components__help__delete_commands() {
 _reactive-graph__components__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph components help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__components__help__get-json-schema_commands] )) ||
+_reactive-graph__components__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph components help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__components__help__help_commands] )) ||
 _reactive-graph__components__help__help_commands() {
@@ -4250,6 +4806,7 @@ _reactive-graph__entity-types_commands() {
 'list-properties:List the properties of an entity type' \
 'list-extensions:List the extensions of an entity type' \
 'list-components:List the components of an entity type' \
+'get-json-schema:Prints the JSON Schema of an entity type' \
 'create:Creates a new entity type' \
 'delete:Deletes a entity type' \
 'add-property:Adds a property to an entity type' \
@@ -4294,6 +4851,11 @@ _reactive-graph__entity-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph entity-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph__entity-types__get-json-schema_commands] )) ||
+_reactive-graph__entity-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph entity-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph__entity-types__help_commands] )) ||
 _reactive-graph__entity-types__help_commands() {
     local commands; commands=(
@@ -4302,6 +4864,7 @@ _reactive-graph__entity-types__help_commands() {
 'list-properties:List the properties of an entity type' \
 'list-extensions:List the extensions of an entity type' \
 'list-components:List the components of an entity type' \
+'get-json-schema:Prints the JSON Schema of an entity type' \
 'create:Creates a new entity type' \
 'delete:Deletes a entity type' \
 'add-property:Adds a property to an entity type' \
@@ -4345,6 +4908,11 @@ _reactive-graph__entity-types__help__delete_commands() {
 _reactive-graph__entity-types__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph entity-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__entity-types__help__get-json-schema_commands] )) ||
+_reactive-graph__entity-types__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph entity-types help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__entity-types__help__help_commands] )) ||
 _reactive-graph__entity-types__help__help_commands() {
@@ -4544,6 +5112,7 @@ _reactive-graph__flow-types_commands() {
 'get:Prints a single flow type' \
 'list-variables:List the variables of a flow type' \
 'list-extensions:List the extensions of a flow type' \
+'get-json-schema:Prints the JSON Schema of a flow type' \
 'create:Creates a new flow type' \
 'delete:Deletes a flow type' \
 'add-variable:Adds a property to a flow type' \
@@ -4588,6 +5157,11 @@ _reactive-graph__flow-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph flow-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph__flow-types__get-json-schema_commands] )) ||
+_reactive-graph__flow-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph flow-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph__flow-types__help_commands] )) ||
 _reactive-graph__flow-types__help_commands() {
     local commands; commands=(
@@ -4595,6 +5169,7 @@ _reactive-graph__flow-types__help_commands() {
 'get:Prints a single flow type' \
 'list-variables:List the variables of a flow type' \
 'list-extensions:List the extensions of a flow type' \
+'get-json-schema:Prints the JSON Schema of a flow type' \
 'create:Creates a new flow type' \
 'delete:Deletes a flow type' \
 'add-variable:Adds a property to a flow type' \
@@ -4638,6 +5213,11 @@ _reactive-graph__flow-types__help__delete_commands() {
 _reactive-graph__flow-types__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph flow-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__flow-types__help__get-json-schema_commands] )) ||
+_reactive-graph__flow-types__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph flow-types help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__flow-types__help__help_commands] )) ||
 _reactive-graph__flow-types__help__help_commands() {
@@ -4724,6 +5304,73 @@ _reactive-graph__flow-types__update-description_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph flow-types update-description commands' commands "$@"
 }
+(( $+functions[_reactive-graph__graphql-schema_commands] )) ||
+_reactive-graph__graphql-schema_commands() {
+    local commands; commands=(
+'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
+'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
+'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
+'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph graphql-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__dynamic-graph-schema_commands] )) ||
+_reactive-graph__graphql-schema__dynamic-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema dynamic-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__help_commands] )) ||
+_reactive-graph__graphql-schema__help_commands() {
+    local commands; commands=(
+'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
+'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
+'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
+'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph graphql-schema help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__help__dynamic-graph-schema_commands] )) ||
+_reactive-graph__graphql-schema__help__dynamic-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema help dynamic-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__help__help_commands] )) ||
+_reactive-graph__graphql-schema__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__help__reactive-graph-plugin-schema_commands] )) ||
+_reactive-graph__graphql-schema__help__reactive-graph-plugin-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema help reactive-graph-plugin-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__help__reactive-graph-runtime-schema_commands] )) ||
+_reactive-graph__graphql-schema__help__reactive-graph-runtime-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema help reactive-graph-runtime-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__help__reactive-graph-schema_commands] )) ||
+_reactive-graph__graphql-schema__help__reactive-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema help reactive-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__reactive-graph-plugin-schema_commands] )) ||
+_reactive-graph__graphql-schema__reactive-graph-plugin-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema reactive-graph-plugin-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__reactive-graph-runtime-schema_commands] )) ||
+_reactive-graph__graphql-schema__reactive-graph-runtime-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema reactive-graph-runtime-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__graphql-schema__reactive-graph-schema_commands] )) ||
+_reactive-graph__graphql-schema__reactive-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph graphql-schema reactive-graph-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph__help_commands] )) ||
 _reactive-graph__help_commands() {
     local commands; commands=(
@@ -4732,7 +5379,8 @@ _reactive-graph__help_commands() {
 'print-markdown-help:Prints the markdown help to stdout' \
 'info:Prints info about this binary' \
 'daemon:Runs the server as daemon' \
-'schema:Prints the GraphQL schema and exits' \
+'graphql-schema:Prints the GraphQL schema and exits' \
+'json-schema:Prints the JSON schema and exits' \
 'execute-command:Executes a command on the client' \
 'instance-info:Prints information about the instance' \
 'plugins:Manage plugins' \
@@ -4745,6 +5393,7 @@ _reactive-graph__help_commands() {
 'entity-instances:Manage entity instances' \
 'relation-instances:Manage relation instances' \
 'flow-instances:Manage flow instances' \
+'introspection:Execute GraphQL introspection queries' \
 'instances:Manage instances' \
 'update:Update the Reactive Graph binary' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -4758,6 +5407,7 @@ _reactive-graph__help__components_commands() {
 'get:Prints a single component' \
 'list-properties:List the properties of a component' \
 'list-extensions:List the extensions of a component' \
+'get-json-schema:Prints the JSON Schema of a component' \
 'create:Creates a new component' \
 'delete:Deletes a component' \
 'add-property:Adds a property to a component' \
@@ -4793,6 +5443,11 @@ _reactive-graph__help__components__delete_commands() {
 _reactive-graph__help__components__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__components__get-json-schema_commands] )) ||
+_reactive-graph__help__components__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help components get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__help__components__json-schema_commands] )) ||
 _reactive-graph__help__components__json-schema_commands() {
@@ -4932,6 +5587,7 @@ _reactive-graph__help__entity-types_commands() {
 'list-properties:List the properties of an entity type' \
 'list-extensions:List the extensions of an entity type' \
 'list-components:List the components of an entity type' \
+'get-json-schema:Prints the JSON Schema of an entity type' \
 'create:Creates a new entity type' \
 'delete:Deletes a entity type' \
 'add-property:Adds a property to an entity type' \
@@ -4974,6 +5630,11 @@ _reactive-graph__help__entity-types__delete_commands() {
 _reactive-graph__help__entity-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__entity-types__get-json-schema_commands] )) ||
+_reactive-graph__help__entity-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help entity-types get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__help__entity-types__json-schema_commands] )) ||
 _reactive-graph__help__entity-types__json-schema_commands() {
@@ -5074,6 +5735,7 @@ _reactive-graph__help__flow-types_commands() {
 'get:Prints a single flow type' \
 'list-variables:List the variables of a flow type' \
 'list-extensions:List the extensions of a flow type' \
+'get-json-schema:Prints the JSON Schema of a flow type' \
 'create:Creates a new flow type' \
 'delete:Deletes a flow type' \
 'add-variable:Adds a property to a flow type' \
@@ -5117,6 +5779,11 @@ _reactive-graph__help__flow-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help flow-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph__help__flow-types__get-json-schema_commands] )) ||
+_reactive-graph__help__flow-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help flow-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph__help__flow-types__json-schema_commands] )) ||
 _reactive-graph__help__flow-types__json-schema_commands() {
     local commands; commands=()
@@ -5156,6 +5823,36 @@ _reactive-graph__help__flow-types__remove-variable_commands() {
 _reactive-graph__help__flow-types__update-description_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help flow-types update-description commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__graphql-schema_commands] )) ||
+_reactive-graph__help__graphql-schema_commands() {
+    local commands; commands=(
+'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
+'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
+'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
+'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
+    )
+    _describe -t commands 'reactive-graph help graphql-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__graphql-schema__dynamic-graph-schema_commands] )) ||
+_reactive-graph__help__graphql-schema__dynamic-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help graphql-schema dynamic-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__graphql-schema__reactive-graph-plugin-schema_commands] )) ||
+_reactive-graph__help__graphql-schema__reactive-graph-plugin-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help graphql-schema reactive-graph-plugin-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__graphql-schema__reactive-graph-runtime-schema_commands] )) ||
+_reactive-graph__help__graphql-schema__reactive-graph-runtime-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help graphql-schema reactive-graph-runtime-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__graphql-schema__reactive-graph-schema_commands] )) ||
+_reactive-graph__help__graphql-schema__reactive-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help graphql-schema reactive-graph-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__help__help_commands] )) ||
 _reactive-graph__help__help_commands() {
@@ -5259,6 +5956,98 @@ _reactive-graph__help__instances__repository__init_commands() {
 _reactive-graph__help__instances__repository__remove_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help instances repository remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__introspection_commands] )) ||
+_reactive-graph__help__introspection_commands() {
+    local commands; commands=(
+'reactive-graph:Get the GraphQL schema of the reactive graph' \
+'dynamic-graph:Get the GraphQL schema of the dynamic graph' \
+'reactive-graph-runtime:Get the GraphQL schema of the reactive graph runtime' \
+'reactive-graph-plugins:Get the GraphQL schema of the plugin system of reactive graph' \
+    )
+    _describe -t commands 'reactive-graph help introspection commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__introspection__dynamic-graph_commands] )) ||
+_reactive-graph__help__introspection__dynamic-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help introspection dynamic-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__introspection__reactive-graph_commands] )) ||
+_reactive-graph__help__introspection__reactive-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help introspection reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__introspection__reactive-graph-plugins_commands] )) ||
+_reactive-graph__help__introspection__reactive-graph-plugins_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help introspection reactive-graph-plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__introspection__reactive-graph-runtime_commands] )) ||
+_reactive-graph__help__introspection__reactive-graph-runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help introspection reactive-graph-runtime commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema_commands] )) ||
+_reactive-graph__help__json-schema_commands() {
+    local commands; commands=(
+'types:Prints the JSON schema of the type system' \
+'instances:Prints the JSON schema of the instance system' \
+    )
+    _describe -t commands 'reactive-graph help json-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__instances_commands] )) ||
+_reactive-graph__help__json-schema__instances_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+    )
+    _describe -t commands 'reactive-graph help json-schema instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__instances__entities_commands] )) ||
+_reactive-graph__help__json-schema__instances__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema instances entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__instances__flows_commands] )) ||
+_reactive-graph__help__json-schema__instances__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema instances flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__instances__relations_commands] )) ||
+_reactive-graph__help__json-schema__instances__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema instances relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__types_commands] )) ||
+_reactive-graph__help__json-schema__types_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+    )
+    _describe -t commands 'reactive-graph help json-schema types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__types__components_commands] )) ||
+_reactive-graph__help__json-schema__types__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema types components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__types__entities_commands] )) ||
+_reactive-graph__help__json-schema__types__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema types entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__types__flows_commands] )) ||
+_reactive-graph__help__json-schema__types__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema types flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__json-schema__types__relations_commands] )) ||
+_reactive-graph__help__json-schema__types__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help json-schema types relations commands' commands "$@"
 }
 (( $+functions[_reactive-graph__help__man-pages_commands] )) ||
 _reactive-graph__help__man-pages_commands() {
@@ -5435,6 +6224,7 @@ _reactive-graph__help__relation-types_commands() {
 'list-properties:List the properties of an relation type' \
 'list-extensions:List the extensions of an relation type' \
 'list-components:List the components of an relation type' \
+'get-json-schema:Prints the JSON Schema of an relation type' \
 'create:Creates a new relation type' \
 'delete:Deletes a relation type' \
 'add-property:Adds a property to a relation type' \
@@ -5477,6 +6267,11 @@ _reactive-graph__help__relation-types__delete_commands() {
 _reactive-graph__help__relation-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__help__relation-types__get-json-schema_commands] )) ||
+_reactive-graph__help__relation-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph help relation-types get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__help__relation-types__json-schema_commands] )) ||
 _reactive-graph__help__relation-types__json-schema_commands() {
@@ -5576,36 +6371,6 @@ _reactive-graph__help__remotes__update_commands() {
 _reactive-graph__help__remotes__update-all_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph help remotes update-all commands' commands "$@"
-}
-(( $+functions[_reactive-graph__help__schema_commands] )) ||
-_reactive-graph__help__schema_commands() {
-    local commands; commands=(
-'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
-'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
-'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
-'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
-    )
-    _describe -t commands 'reactive-graph help schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__help__schema__dynamic-graph-schema_commands] )) ||
-_reactive-graph__help__schema__dynamic-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph help schema dynamic-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__help__schema__reactive-graph-plugin-schema_commands] )) ||
-_reactive-graph__help__schema__reactive-graph-plugin-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph help schema reactive-graph-plugin-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__help__schema__reactive-graph-runtime-schema_commands] )) ||
-_reactive-graph__help__schema__reactive-graph-runtime-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph help schema reactive-graph-runtime-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__help__schema__reactive-graph-schema_commands] )) ||
-_reactive-graph__help__schema__reactive-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph help schema reactive-graph-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__help__shell-completions_commands] )) ||
 _reactive-graph__help__shell-completions_commands() {
@@ -5933,6 +6698,272 @@ _reactive-graph__instances__repository__init_commands() {
 _reactive-graph__instances__repository__remove_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph instances repository remove commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection_commands] )) ||
+_reactive-graph__introspection_commands() {
+    local commands; commands=(
+'reactive-graph:Get the GraphQL schema of the reactive graph' \
+'dynamic-graph:Get the GraphQL schema of the dynamic graph' \
+'reactive-graph-runtime:Get the GraphQL schema of the reactive graph runtime' \
+'reactive-graph-plugins:Get the GraphQL schema of the plugin system of reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph introspection commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__dynamic-graph_commands] )) ||
+_reactive-graph__introspection__dynamic-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection dynamic-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__help_commands] )) ||
+_reactive-graph__introspection__help_commands() {
+    local commands; commands=(
+'reactive-graph:Get the GraphQL schema of the reactive graph' \
+'dynamic-graph:Get the GraphQL schema of the dynamic graph' \
+'reactive-graph-runtime:Get the GraphQL schema of the reactive graph runtime' \
+'reactive-graph-plugins:Get the GraphQL schema of the plugin system of reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph introspection help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__help__dynamic-graph_commands] )) ||
+_reactive-graph__introspection__help__dynamic-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection help dynamic-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__help__help_commands] )) ||
+_reactive-graph__introspection__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__help__reactive-graph_commands] )) ||
+_reactive-graph__introspection__help__reactive-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection help reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__help__reactive-graph-plugins_commands] )) ||
+_reactive-graph__introspection__help__reactive-graph-plugins_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection help reactive-graph-plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__help__reactive-graph-runtime_commands] )) ||
+_reactive-graph__introspection__help__reactive-graph-runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection help reactive-graph-runtime commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__reactive-graph_commands] )) ||
+_reactive-graph__introspection__reactive-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__reactive-graph-plugins_commands] )) ||
+_reactive-graph__introspection__reactive-graph-plugins_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection reactive-graph-plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph__introspection__reactive-graph-runtime_commands] )) ||
+_reactive-graph__introspection__reactive-graph-runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph introspection reactive-graph-runtime commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema_commands] )) ||
+_reactive-graph__json-schema_commands() {
+    local commands; commands=(
+'types:Prints the JSON schema of the type system' \
+'instances:Prints the JSON schema of the instance system' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph json-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help_commands] )) ||
+_reactive-graph__json-schema__help_commands() {
+    local commands; commands=(
+'types:Prints the JSON schema of the type system' \
+'instances:Prints the JSON schema of the instance system' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph json-schema help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__help_commands] )) ||
+_reactive-graph__json-schema__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__instances_commands] )) ||
+_reactive-graph__json-schema__help__instances_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+    )
+    _describe -t commands 'reactive-graph json-schema help instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__instances__entities_commands] )) ||
+_reactive-graph__json-schema__help__instances__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help instances entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__instances__flows_commands] )) ||
+_reactive-graph__json-schema__help__instances__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help instances flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__instances__relations_commands] )) ||
+_reactive-graph__json-schema__help__instances__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help instances relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__types_commands] )) ||
+_reactive-graph__json-schema__help__types_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+    )
+    _describe -t commands 'reactive-graph json-schema help types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__types__components_commands] )) ||
+_reactive-graph__json-schema__help__types__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help types components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__types__entities_commands] )) ||
+_reactive-graph__json-schema__help__types__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help types entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__types__flows_commands] )) ||
+_reactive-graph__json-schema__help__types__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help types flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__help__types__relations_commands] )) ||
+_reactive-graph__json-schema__help__types__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema help types relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances_commands] )) ||
+_reactive-graph__json-schema__instances_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph json-schema instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__entities_commands] )) ||
+_reactive-graph__json-schema__instances__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__flows_commands] )) ||
+_reactive-graph__json-schema__instances__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__help_commands] )) ||
+_reactive-graph__json-schema__instances__help_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph json-schema instances help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__help__entities_commands] )) ||
+_reactive-graph__json-schema__instances__help__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances help entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__help__flows_commands] )) ||
+_reactive-graph__json-schema__instances__help__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances help flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__help__help_commands] )) ||
+_reactive-graph__json-schema__instances__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__help__relations_commands] )) ||
+_reactive-graph__json-schema__instances__help__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances help relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__instances__relations_commands] )) ||
+_reactive-graph__json-schema__instances__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema instances relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types_commands] )) ||
+_reactive-graph__json-schema__types_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph json-schema types commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__components_commands] )) ||
+_reactive-graph__json-schema__types__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__entities_commands] )) ||
+_reactive-graph__json-schema__types__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__flows_commands] )) ||
+_reactive-graph__json-schema__types__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__help_commands] )) ||
+_reactive-graph__json-schema__types__help_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph json-schema types help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__help__components_commands] )) ||
+_reactive-graph__json-schema__types__help__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types help components commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__help__entities_commands] )) ||
+_reactive-graph__json-schema__types__help__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types help entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__help__flows_commands] )) ||
+_reactive-graph__json-schema__types__help__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types help flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__help__help_commands] )) ||
+_reactive-graph__json-schema__types__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__help__relations_commands] )) ||
+_reactive-graph__json-schema__types__help__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types help relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph__json-schema__types__relations_commands] )) ||
+_reactive-graph__json-schema__types__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph json-schema types relations commands' commands "$@"
 }
 (( $+functions[_reactive-graph__man-pages_commands] )) ||
 _reactive-graph__man-pages_commands() {
@@ -6292,6 +7323,7 @@ _reactive-graph__relation-types_commands() {
 'list-properties:List the properties of an relation type' \
 'list-extensions:List the extensions of an relation type' \
 'list-components:List the components of an relation type' \
+'get-json-schema:Prints the JSON Schema of an relation type' \
 'create:Creates a new relation type' \
 'delete:Deletes a relation type' \
 'add-property:Adds a property to a relation type' \
@@ -6336,6 +7368,11 @@ _reactive-graph__relation-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph relation-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph__relation-types__get-json-schema_commands] )) ||
+_reactive-graph__relation-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph relation-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph__relation-types__help_commands] )) ||
 _reactive-graph__relation-types__help_commands() {
     local commands; commands=(
@@ -6344,6 +7381,7 @@ _reactive-graph__relation-types__help_commands() {
 'list-properties:List the properties of an relation type' \
 'list-extensions:List the extensions of an relation type' \
 'list-components:List the components of an relation type' \
+'get-json-schema:Prints the JSON Schema of an relation type' \
 'create:Creates a new relation type' \
 'delete:Deletes a relation type' \
 'add-property:Adds a property to a relation type' \
@@ -6387,6 +7425,11 @@ _reactive-graph__relation-types__help__delete_commands() {
 _reactive-graph__relation-types__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph relation-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph__relation-types__help__get-json-schema_commands] )) ||
+_reactive-graph__relation-types__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph relation-types help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__relation-types__help__help_commands] )) ||
 _reactive-graph__relation-types__help__help_commands() {
@@ -6597,73 +7640,6 @@ _reactive-graph__remotes__update_commands() {
 _reactive-graph__remotes__update-all_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph remotes update-all commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema_commands] )) ||
-_reactive-graph__schema_commands() {
-    local commands; commands=(
-'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
-'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
-'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
-'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
-'help:Print this message or the help of the given subcommand(s)' \
-    )
-    _describe -t commands 'reactive-graph schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__dynamic-graph-schema_commands] )) ||
-_reactive-graph__schema__dynamic-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema dynamic-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__help_commands] )) ||
-_reactive-graph__schema__help_commands() {
-    local commands; commands=(
-'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
-'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
-'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
-'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
-'help:Print this message or the help of the given subcommand(s)' \
-    )
-    _describe -t commands 'reactive-graph schema help commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__help__dynamic-graph-schema_commands] )) ||
-_reactive-graph__schema__help__dynamic-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema help dynamic-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__help__help_commands] )) ||
-_reactive-graph__schema__help__help_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema help help commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__help__reactive-graph-plugin-schema_commands] )) ||
-_reactive-graph__schema__help__reactive-graph-plugin-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema help reactive-graph-plugin-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__help__reactive-graph-runtime-schema_commands] )) ||
-_reactive-graph__schema__help__reactive-graph-runtime-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema help reactive-graph-runtime-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__help__reactive-graph-schema_commands] )) ||
-_reactive-graph__schema__help__reactive-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema help reactive-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__reactive-graph-plugin-schema_commands] )) ||
-_reactive-graph__schema__reactive-graph-plugin-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema reactive-graph-plugin-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__reactive-graph-runtime-schema_commands] )) ||
-_reactive-graph__schema__reactive-graph-runtime-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema reactive-graph-runtime-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph__schema__reactive-graph-schema_commands] )) ||
-_reactive-graph__schema__reactive-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph schema reactive-graph-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph__shell-completions_commands] )) ||
 _reactive-graph__shell-completions_commands() {

--- a/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-client
+++ b/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-client
@@ -23,19 +23,21 @@ _reactive-graph-client() {
 '--endpoint-runtime=[The endpoint to use]:ENDPOINT_RUNTIME:_default' \
 '--endpoint-plugins=[The endpoint to use]:ENDPOINT_PLUGINS:_default' \
 '--bearer=[The authentication token]:BEARER:_default' \
-'-h[Print help]' \
-'--help[Print help]' \
+'--danger-accept-invalid-certs=[Controls the use of certificate validation]:DANGER_ACCEPT_INVALID_CERTS:(true false)' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
+'::danger_accept_invalid_hostnames -- Controls the use of hostname verification:(true false)' \
 ":: :_reactive-graph-client_commands" \
 "*::: :->reactive-graph-client" \
 && ret=0
     case $state in
     (reactive-graph-client)
-        words=($line[1] "${words[@]}")
+        words=($line[2] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-client-command-$line[1]:"
-        case $line[1] in
+        curcontext="${curcontext%:*:*}:reactive-graph-client-command-$line[2]:"
+        case $line[2] in
             (shell-completions)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
@@ -623,6 +625,18 @@ _arguments "${_arguments_options[@]}" : \
 ':name -- The component name:_default' \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The component namespace:_default' \
+':name -- The component name:_default' \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -759,6 +773,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -868,6 +886,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The entity type namespace:_default' \
+':name -- The entity type name:_default' \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
 '--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -1047,6 +1077,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1164,6 +1198,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-components)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The relation type namespace:_default' \
+':name -- The relation type name:_default' \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
 '--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -1347,6 +1393,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1452,6 +1502,18 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-extensions)
+_arguments "${_arguments_options[@]}" : \
+'-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':namespace -- The flow type namespace:_default' \
+':name -- The flow type name:_default' \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 '-o+[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
 '--output-format=[]:OUTPUT_FORMAT:(table html-table markdown-table count json json5 toml)' \
@@ -1633,6 +1695,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -2430,6 +2496,94 @@ esac
     ;;
 esac
 ;;
+(introspection)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph-client__introspection_commands" \
+"*::: :->introspection" \
+&& ret=0
+
+    case $state in
+    (introspection)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-introspection-command-$line[1]:"
+        case $line[1] in
+            (reactive-graph)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(dynamic-graph)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(reactive-graph-runtime)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(reactive-graph-plugins)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__introspection__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-introspection-help-command-$line[1]:"
+        case $line[1] in
+            (reactive-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dynamic-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-runtime)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-plugins)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 ":: :_reactive-graph-client__help_commands" \
@@ -2654,6 +2808,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -2719,6 +2877,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -2798,6 +2960,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(get-json-schema)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (create)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -2867,6 +3033,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (list-extensions)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(get-json-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -3094,6 +3264,38 @@ _arguments "${_arguments_options[@]}" : \
     ;;
 esac
 ;;
+(introspection)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-client__help__introspection_commands" \
+"*::: :->introspection" \
+&& ret=0
+
+    case $state in
+    (introspection)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-client-help-introspection-command-$line[1]:"
+        case $line[1] in
+            (reactive-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(dynamic-graph)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-runtime)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(reactive-graph-plugins)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -3126,6 +3328,7 @@ _reactive-graph-client_commands() {
 'entity-instances:Manage entity instances' \
 'relation-instances:Manage relation instances' \
 'flow-instances:Manage flow instances' \
+'introspection:Execute GraphQL introspection queries' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'reactive-graph-client commands' commands "$@"
@@ -3137,6 +3340,7 @@ _reactive-graph-client__components_commands() {
 'get:Prints a single component' \
 'list-properties:List the properties of a component' \
 'list-extensions:List the extensions of a component' \
+'get-json-schema:Prints the JSON Schema of a component' \
 'create:Creates a new component' \
 'delete:Deletes a component' \
 'add-property:Adds a property to a component' \
@@ -3174,6 +3378,11 @@ _reactive-graph-client__components__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client components get commands' commands "$@"
 }
+(( $+functions[_reactive-graph-client__components__get-json-schema_commands] )) ||
+_reactive-graph-client__components__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph-client__components__help_commands] )) ||
 _reactive-graph-client__components__help_commands() {
     local commands; commands=(
@@ -3181,6 +3390,7 @@ _reactive-graph-client__components__help_commands() {
 'get:Prints a single component' \
 'list-properties:List the properties of a component' \
 'list-extensions:List the extensions of a component' \
+'get-json-schema:Prints the JSON Schema of a component' \
 'create:Creates a new component' \
 'delete:Deletes a component' \
 'add-property:Adds a property to a component' \
@@ -3217,6 +3427,11 @@ _reactive-graph-client__components__help__delete_commands() {
 _reactive-graph-client__components__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client components help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__components__help__get-json-schema_commands] )) ||
+_reactive-graph-client__components__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client components help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__components__help__help_commands] )) ||
 _reactive-graph-client__components__help__help_commands() {
@@ -3488,6 +3703,7 @@ _reactive-graph-client__entity-types_commands() {
 'list-properties:List the properties of an entity type' \
 'list-extensions:List the extensions of an entity type' \
 'list-components:List the components of an entity type' \
+'get-json-schema:Prints the JSON Schema of an entity type' \
 'create:Creates a new entity type' \
 'delete:Deletes a entity type' \
 'add-property:Adds a property to an entity type' \
@@ -3532,6 +3748,11 @@ _reactive-graph-client__entity-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client entity-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph-client__entity-types__get-json-schema_commands] )) ||
+_reactive-graph-client__entity-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph-client__entity-types__help_commands] )) ||
 _reactive-graph-client__entity-types__help_commands() {
     local commands; commands=(
@@ -3540,6 +3761,7 @@ _reactive-graph-client__entity-types__help_commands() {
 'list-properties:List the properties of an entity type' \
 'list-extensions:List the extensions of an entity type' \
 'list-components:List the components of an entity type' \
+'get-json-schema:Prints the JSON Schema of an entity type' \
 'create:Creates a new entity type' \
 'delete:Deletes a entity type' \
 'add-property:Adds a property to an entity type' \
@@ -3583,6 +3805,11 @@ _reactive-graph-client__entity-types__help__delete_commands() {
 _reactive-graph-client__entity-types__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client entity-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__entity-types__help__get-json-schema_commands] )) ||
+_reactive-graph-client__entity-types__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client entity-types help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__entity-types__help__help_commands] )) ||
 _reactive-graph-client__entity-types__help__help_commands() {
@@ -3782,6 +4009,7 @@ _reactive-graph-client__flow-types_commands() {
 'get:Prints a single flow type' \
 'list-variables:List the variables of a flow type' \
 'list-extensions:List the extensions of a flow type' \
+'get-json-schema:Prints the JSON Schema of a flow type' \
 'create:Creates a new flow type' \
 'delete:Deletes a flow type' \
 'add-variable:Adds a property to a flow type' \
@@ -3826,6 +4054,11 @@ _reactive-graph-client__flow-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client flow-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph-client__flow-types__get-json-schema_commands] )) ||
+_reactive-graph-client__flow-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client flow-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph-client__flow-types__help_commands] )) ||
 _reactive-graph-client__flow-types__help_commands() {
     local commands; commands=(
@@ -3833,6 +4066,7 @@ _reactive-graph-client__flow-types__help_commands() {
 'get:Prints a single flow type' \
 'list-variables:List the variables of a flow type' \
 'list-extensions:List the extensions of a flow type' \
+'get-json-schema:Prints the JSON Schema of a flow type' \
 'create:Creates a new flow type' \
 'delete:Deletes a flow type' \
 'add-variable:Adds a property to a flow type' \
@@ -3876,6 +4110,11 @@ _reactive-graph-client__flow-types__help__delete_commands() {
 _reactive-graph-client__flow-types__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client flow-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__flow-types__help__get-json-schema_commands] )) ||
+_reactive-graph-client__flow-types__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client flow-types help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__flow-types__help__help_commands] )) ||
 _reactive-graph-client__flow-types__help__help_commands() {
@@ -3981,6 +4220,7 @@ _reactive-graph-client__help_commands() {
 'entity-instances:Manage entity instances' \
 'relation-instances:Manage relation instances' \
 'flow-instances:Manage flow instances' \
+'introspection:Execute GraphQL introspection queries' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'reactive-graph-client help commands' commands "$@"
@@ -3992,6 +4232,7 @@ _reactive-graph-client__help__components_commands() {
 'get:Prints a single component' \
 'list-properties:List the properties of a component' \
 'list-extensions:List the extensions of a component' \
+'get-json-schema:Prints the JSON Schema of a component' \
 'create:Creates a new component' \
 'delete:Deletes a component' \
 'add-property:Adds a property to a component' \
@@ -4027,6 +4268,11 @@ _reactive-graph-client__help__components__delete_commands() {
 _reactive-graph-client__help__components__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client help components get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__components__get-json-schema_commands] )) ||
+_reactive-graph-client__help__components__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help components get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__help__components__json-schema_commands] )) ||
 _reactive-graph-client__help__components__json-schema_commands() {
@@ -4161,6 +4407,7 @@ _reactive-graph-client__help__entity-types_commands() {
 'list-properties:List the properties of an entity type' \
 'list-extensions:List the extensions of an entity type' \
 'list-components:List the components of an entity type' \
+'get-json-schema:Prints the JSON Schema of an entity type' \
 'create:Creates a new entity type' \
 'delete:Deletes a entity type' \
 'add-property:Adds a property to an entity type' \
@@ -4203,6 +4450,11 @@ _reactive-graph-client__help__entity-types__delete_commands() {
 _reactive-graph-client__help__entity-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client help entity-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__entity-types__get-json-schema_commands] )) ||
+_reactive-graph-client__help__entity-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help entity-types get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__help__entity-types__json-schema_commands] )) ||
 _reactive-graph-client__help__entity-types__json-schema_commands() {
@@ -4303,6 +4555,7 @@ _reactive-graph-client__help__flow-types_commands() {
 'get:Prints a single flow type' \
 'list-variables:List the variables of a flow type' \
 'list-extensions:List the extensions of a flow type' \
+'get-json-schema:Prints the JSON Schema of a flow type' \
 'create:Creates a new flow type' \
 'delete:Deletes a flow type' \
 'add-variable:Adds a property to a flow type' \
@@ -4345,6 +4598,11 @@ _reactive-graph-client__help__flow-types__delete_commands() {
 _reactive-graph-client__help__flow-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client help flow-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__flow-types__get-json-schema_commands] )) ||
+_reactive-graph-client__help__flow-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help flow-types get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__help__flow-types__json-schema_commands] )) ||
 _reactive-graph-client__help__flow-types__json-schema_commands() {
@@ -4407,6 +4665,36 @@ _reactive-graph-client__help__instance-info_commands() {
 _reactive-graph-client__help__instance-info__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client help instance-info get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__introspection_commands] )) ||
+_reactive-graph-client__help__introspection_commands() {
+    local commands; commands=(
+'reactive-graph:Get the GraphQL schema of the reactive graph' \
+'dynamic-graph:Get the GraphQL schema of the dynamic graph' \
+'reactive-graph-runtime:Get the GraphQL schema of the reactive graph runtime' \
+'reactive-graph-plugins:Get the GraphQL schema of the plugin system of reactive graph' \
+    )
+    _describe -t commands 'reactive-graph-client help introspection commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__introspection__dynamic-graph_commands] )) ||
+_reactive-graph-client__help__introspection__dynamic-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help introspection dynamic-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__introspection__reactive-graph_commands] )) ||
+_reactive-graph-client__help__introspection__reactive-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help introspection reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__introspection__reactive-graph-plugins_commands] )) ||
+_reactive-graph-client__help__introspection__reactive-graph-plugins_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help introspection reactive-graph-plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__introspection__reactive-graph-runtime_commands] )) ||
+_reactive-graph-client__help__introspection__reactive-graph-runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help introspection reactive-graph-runtime commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__help__man-pages_commands] )) ||
 _reactive-graph-client__help__man-pages_commands() {
@@ -4583,6 +4871,7 @@ _reactive-graph-client__help__relation-types_commands() {
 'list-properties:List the properties of an relation type' \
 'list-extensions:List the extensions of an relation type' \
 'list-components:List the components of an relation type' \
+'get-json-schema:Prints the JSON Schema of an relation type' \
 'create:Creates a new relation type' \
 'delete:Deletes a relation type' \
 'add-property:Adds a property to a relation type' \
@@ -4625,6 +4914,11 @@ _reactive-graph-client__help__relation-types__delete_commands() {
 _reactive-graph-client__help__relation-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client help relation-types get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__help__relation-types__get-json-schema_commands] )) ||
+_reactive-graph-client__help__relation-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client help relation-types get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__help__relation-types__json-schema_commands] )) ||
 _reactive-graph-client__help__relation-types__json-schema_commands() {
@@ -4783,6 +5077,73 @@ _reactive-graph-client__instance-info__help__get_commands() {
 _reactive-graph-client__instance-info__help__help_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client instance-info help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection_commands] )) ||
+_reactive-graph-client__introspection_commands() {
+    local commands; commands=(
+'reactive-graph:Get the GraphQL schema of the reactive graph' \
+'dynamic-graph:Get the GraphQL schema of the dynamic graph' \
+'reactive-graph-runtime:Get the GraphQL schema of the reactive graph runtime' \
+'reactive-graph-plugins:Get the GraphQL schema of the plugin system of reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client introspection commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__dynamic-graph_commands] )) ||
+_reactive-graph-client__introspection__dynamic-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection dynamic-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__help_commands] )) ||
+_reactive-graph-client__introspection__help_commands() {
+    local commands; commands=(
+'reactive-graph:Get the GraphQL schema of the reactive graph' \
+'dynamic-graph:Get the GraphQL schema of the dynamic graph' \
+'reactive-graph-runtime:Get the GraphQL schema of the reactive graph runtime' \
+'reactive-graph-plugins:Get the GraphQL schema of the plugin system of reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-client introspection help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__help__dynamic-graph_commands] )) ||
+_reactive-graph-client__introspection__help__dynamic-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection help dynamic-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__help__help_commands] )) ||
+_reactive-graph-client__introspection__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__help__reactive-graph_commands] )) ||
+_reactive-graph-client__introspection__help__reactive-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection help reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__help__reactive-graph-plugins_commands] )) ||
+_reactive-graph-client__introspection__help__reactive-graph-plugins_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection help reactive-graph-plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__help__reactive-graph-runtime_commands] )) ||
+_reactive-graph-client__introspection__help__reactive-graph-runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection help reactive-graph-runtime commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__reactive-graph_commands] )) ||
+_reactive-graph-client__introspection__reactive-graph_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection reactive-graph commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__reactive-graph-plugins_commands] )) ||
+_reactive-graph-client__introspection__reactive-graph-plugins_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection reactive-graph-plugins commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__introspection__reactive-graph-runtime_commands] )) ||
+_reactive-graph-client__introspection__reactive-graph-runtime_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client introspection reactive-graph-runtime commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__man-pages_commands] )) ||
 _reactive-graph-client__man-pages_commands() {
@@ -5142,6 +5503,7 @@ _reactive-graph-client__relation-types_commands() {
 'list-properties:List the properties of an relation type' \
 'list-extensions:List the extensions of an relation type' \
 'list-components:List the components of an relation type' \
+'get-json-schema:Prints the JSON Schema of an relation type' \
 'create:Creates a new relation type' \
 'delete:Deletes a relation type' \
 'add-property:Adds a property to a relation type' \
@@ -5186,6 +5548,11 @@ _reactive-graph-client__relation-types__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client relation-types get commands' commands "$@"
 }
+(( $+functions[_reactive-graph-client__relation-types__get-json-schema_commands] )) ||
+_reactive-graph-client__relation-types__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types get-json-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph-client__relation-types__help_commands] )) ||
 _reactive-graph-client__relation-types__help_commands() {
     local commands; commands=(
@@ -5194,6 +5561,7 @@ _reactive-graph-client__relation-types__help_commands() {
 'list-properties:List the properties of an relation type' \
 'list-extensions:List the extensions of an relation type' \
 'list-components:List the components of an relation type' \
+'get-json-schema:Prints the JSON Schema of an relation type' \
 'create:Creates a new relation type' \
 'delete:Deletes a relation type' \
 'add-property:Adds a property to a relation type' \
@@ -5237,6 +5605,11 @@ _reactive-graph-client__relation-types__help__delete_commands() {
 _reactive-graph-client__relation-types__help__get_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-client relation-types help get commands' commands "$@"
+}
+(( $+functions[_reactive-graph-client__relation-types__help__get-json-schema_commands] )) ||
+_reactive-graph-client__relation-types__help__get-json-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-client relation-types help get-json-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-client__relation-types__help__help_commands] )) ||
 _reactive-graph-client__relation-types__help__help_commands() {

--- a/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-server
+++ b/crates/reactive-graph/debian/usr/share/zsh/functions/Completion/Base/_reactive-graph-server
@@ -220,21 +220,21 @@ _arguments "${_arguments_options[@]}" : \
 '--version[Print version]' \
 && ret=0
 ;;
-(schema)
+(graphql-schema)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_reactive-graph-server__schema_commands" \
-"*::: :->schema" \
+":: :_reactive-graph-server__graphql-schema_commands" \
+"*::: :->graphql-schema" \
 && ret=0
 
     case $state in
-    (schema)
+    (graphql-schema)
         words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-server-schema-command-$line[1]:"
+        curcontext="${curcontext%:*:*}:reactive-graph-server-graphql-schema-command-$line[1]:"
         case $line[1] in
             (reactive-graph-schema)
 _arguments "${_arguments_options[@]}" : \
@@ -270,7 +270,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_reactive-graph-server__schema__help_commands" \
+":: :_reactive-graph-server__graphql-schema__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -278,7 +278,7 @@ _arguments "${_arguments_options[@]}" : \
     (help)
         words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-server-schema-help-command-$line[1]:"
+        curcontext="${curcontext%:*:*}:reactive-graph-server-graphql-schema-help-command-$line[1]:"
         case $line[1] in
             (reactive-graph-schema)
 _arguments "${_arguments_options[@]}" : \
@@ -295,6 +295,270 @@ _arguments "${_arguments_options[@]}" : \
 (reactive-graph-runtime-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(json-schema)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph-server__json-schema_commands" \
+"*::: :->json-schema" \
+&& ret=0
+
+    case $state in
+    (json-schema)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-command-$line[1]:"
+        case $line[1] in
+            (types)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph-server__json-schema__types_commands" \
+"*::: :->types" \
+&& ret=0
+
+    case $state in
+    (types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-types-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__json-schema__types__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-types-help-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_reactive-graph-server__json-schema__instances_commands" \
+"*::: :->instances" \
+&& ret=0
+
+    case $state in
+    (instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-instances-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__json-schema__instances__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-instances-help-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__json-schema__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-help-command-$line[1]:"
+        case $line[1] in
+            (types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__json-schema__help__types_commands" \
+"*::: :->types" \
+&& ret=0
+
+    case $state in
+    (types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-help-types-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__json-schema__help__instances_commands" \
+"*::: :->instances" \
+&& ret=0
+
+    case $state in
+    (instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-json-schema-help-instances-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
@@ -380,17 +644,17 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
-(schema)
+(graphql-schema)
 _arguments "${_arguments_options[@]}" : \
-":: :_reactive-graph-server__help__schema_commands" \
-"*::: :->schema" \
+":: :_reactive-graph-server__help__graphql-schema_commands" \
+"*::: :->graphql-schema" \
 && ret=0
 
     case $state in
-    (schema)
+    (graphql-schema)
         words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:reactive-graph-server-help-schema-command-$line[1]:"
+        curcontext="${curcontext%:*:*}:reactive-graph-server-help-graphql-schema-command-$line[1]:"
         case $line[1] in
             (reactive-graph-schema)
 _arguments "${_arguments_options[@]}" : \
@@ -407,6 +671,82 @@ _arguments "${_arguments_options[@]}" : \
 (reactive-graph-runtime-schema)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(json-schema)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__help__json-schema_commands" \
+"*::: :->json-schema" \
+&& ret=0
+
+    case $state in
+    (json-schema)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-help-json-schema-command-$line[1]:"
+        case $line[1] in
+            (types)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__help__json-schema__types_commands" \
+"*::: :->types" \
+&& ret=0
+
+    case $state in
+    (types)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-help-json-schema-types-command-$line[1]:"
+        case $line[1] in
+            (components)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(instances)
+_arguments "${_arguments_options[@]}" : \
+":: :_reactive-graph-server__help__json-schema__instances_commands" \
+"*::: :->instances" \
+&& ret=0
+
+    case $state in
+    (instances)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:reactive-graph-server-help-json-schema-instances-command-$line[1]:"
+        case $line[1] in
+            (entities)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(relations)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(flows)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
         esac
     ;;
@@ -433,7 +773,8 @@ _reactive-graph-server_commands() {
 'print-markdown-help:Prints the markdown help to stdout' \
 'info:Prints info about this binary' \
 'daemon:Runs the server as daemon' \
-'schema:Prints the GraphQL schema and exits' \
+'graphql-schema:Prints the GraphQL schema and exits' \
+'json-schema:Prints the JSON schema and exits' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'reactive-graph-server commands' commands "$@"
@@ -443,6 +784,73 @@ _reactive-graph-server__daemon_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-server daemon commands' commands "$@"
 }
+(( $+functions[_reactive-graph-server__graphql-schema_commands] )) ||
+_reactive-graph-server__graphql-schema_commands() {
+    local commands; commands=(
+'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
+'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
+'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
+'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server graphql-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__dynamic-graph-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__dynamic-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema dynamic-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__help_commands] )) ||
+_reactive-graph-server__graphql-schema__help_commands() {
+    local commands; commands=(
+'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
+'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
+'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
+'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server graphql-schema help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__help__dynamic-graph-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__help__dynamic-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema help dynamic-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__help__help_commands] )) ||
+_reactive-graph-server__graphql-schema__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__help__reactive-graph-plugin-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__help__reactive-graph-plugin-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema help reactive-graph-plugin-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__help__reactive-graph-runtime-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__help__reactive-graph-runtime-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema help reactive-graph-runtime-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__help__reactive-graph-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__help__reactive-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema help reactive-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__reactive-graph-plugin-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__reactive-graph-plugin-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema reactive-graph-plugin-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__reactive-graph-runtime-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__reactive-graph-runtime-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema reactive-graph-runtime-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__graphql-schema__reactive-graph-schema_commands] )) ||
+_reactive-graph-server__graphql-schema__reactive-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server graphql-schema reactive-graph-schema commands' commands "$@"
+}
 (( $+functions[_reactive-graph-server__help_commands] )) ||
 _reactive-graph-server__help_commands() {
     local commands; commands=(
@@ -451,7 +859,8 @@ _reactive-graph-server__help_commands() {
 'print-markdown-help:Prints the markdown help to stdout' \
 'info:Prints info about this binary' \
 'daemon:Runs the server as daemon' \
-'schema:Prints the GraphQL schema and exits' \
+'graphql-schema:Prints the GraphQL schema and exits' \
+'json-schema:Prints the JSON schema and exits' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'reactive-graph-server help commands' commands "$@"
@@ -460,6 +869,36 @@ _reactive-graph-server__help_commands() {
 _reactive-graph-server__help__daemon_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-server help daemon commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__graphql-schema_commands] )) ||
+_reactive-graph-server__help__graphql-schema_commands() {
+    local commands; commands=(
+'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
+'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
+'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
+'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
+    )
+    _describe -t commands 'reactive-graph-server help graphql-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__graphql-schema__dynamic-graph-schema_commands] )) ||
+_reactive-graph-server__help__graphql-schema__dynamic-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help graphql-schema dynamic-graph-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__graphql-schema__reactive-graph-plugin-schema_commands] )) ||
+_reactive-graph-server__help__graphql-schema__reactive-graph-plugin-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help graphql-schema reactive-graph-plugin-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__graphql-schema__reactive-graph-runtime-schema_commands] )) ||
+_reactive-graph-server__help__graphql-schema__reactive-graph-runtime-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help graphql-schema reactive-graph-runtime-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__graphql-schema__reactive-graph-schema_commands] )) ||
+_reactive-graph-server__help__graphql-schema__reactive-graph-schema_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help graphql-schema reactive-graph-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-server__help__help_commands] )) ||
 _reactive-graph-server__help__help_commands() {
@@ -470,6 +909,68 @@ _reactive-graph-server__help__help_commands() {
 _reactive-graph-server__help__info_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-server help info commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema_commands] )) ||
+_reactive-graph-server__help__json-schema_commands() {
+    local commands; commands=(
+'types:Prints the JSON schema of the type system' \
+'instances:Prints the JSON schema of the instance system' \
+    )
+    _describe -t commands 'reactive-graph-server help json-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__instances_commands] )) ||
+_reactive-graph-server__help__json-schema__instances_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+    )
+    _describe -t commands 'reactive-graph-server help json-schema instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__instances__entities_commands] )) ||
+_reactive-graph-server__help__json-schema__instances__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema instances entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__instances__flows_commands] )) ||
+_reactive-graph-server__help__json-schema__instances__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema instances flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__instances__relations_commands] )) ||
+_reactive-graph-server__help__json-schema__instances__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema instances relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__types_commands] )) ||
+_reactive-graph-server__help__json-schema__types_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+    )
+    _describe -t commands 'reactive-graph-server help json-schema types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__types__components_commands] )) ||
+_reactive-graph-server__help__json-schema__types__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema types components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__types__entities_commands] )) ||
+_reactive-graph-server__help__json-schema__types__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema types entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__types__flows_commands] )) ||
+_reactive-graph-server__help__json-schema__types__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema types flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__help__json-schema__types__relations_commands] )) ||
+_reactive-graph-server__help__json-schema__types__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server help json-schema types relations commands' commands "$@"
 }
 (( $+functions[_reactive-graph-server__help__man-pages_commands] )) ||
 _reactive-graph-server__help__man-pages_commands() {
@@ -494,36 +995,6 @@ _reactive-graph-server__help__print-markdown-help_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-server help print-markdown-help commands' commands "$@"
 }
-(( $+functions[_reactive-graph-server__help__schema_commands] )) ||
-_reactive-graph-server__help__schema_commands() {
-    local commands; commands=(
-'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
-'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
-'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
-'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
-    )
-    _describe -t commands 'reactive-graph-server help schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__help__schema__dynamic-graph-schema_commands] )) ||
-_reactive-graph-server__help__schema__dynamic-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server help schema dynamic-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__help__schema__reactive-graph-plugin-schema_commands] )) ||
-_reactive-graph-server__help__schema__reactive-graph-plugin-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server help schema reactive-graph-plugin-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__help__schema__reactive-graph-runtime-schema_commands] )) ||
-_reactive-graph-server__help__schema__reactive-graph-runtime-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server help schema reactive-graph-runtime-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__help__schema__reactive-graph-schema_commands] )) ||
-_reactive-graph-server__help__schema__reactive-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server help schema reactive-graph-schema commands' commands "$@"
-}
 (( $+functions[_reactive-graph-server__help__shell-completions_commands] )) ||
 _reactive-graph-server__help__shell-completions_commands() {
     local commands; commands=(
@@ -546,6 +1017,205 @@ _reactive-graph-server__help__shell-completions__print_commands() {
 _reactive-graph-server__info_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-server info commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema_commands] )) ||
+_reactive-graph-server__json-schema_commands() {
+    local commands; commands=(
+'types:Prints the JSON schema of the type system' \
+'instances:Prints the JSON schema of the instance system' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help_commands] )) ||
+_reactive-graph-server__json-schema__help_commands() {
+    local commands; commands=(
+'types:Prints the JSON schema of the type system' \
+'instances:Prints the JSON schema of the instance system' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__help_commands] )) ||
+_reactive-graph-server__json-schema__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__instances_commands] )) ||
+_reactive-graph-server__json-schema__help__instances_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema help instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__instances__entities_commands] )) ||
+_reactive-graph-server__json-schema__help__instances__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help instances entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__instances__flows_commands] )) ||
+_reactive-graph-server__json-schema__help__instances__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help instances flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__instances__relations_commands] )) ||
+_reactive-graph-server__json-schema__help__instances__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help instances relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__types_commands] )) ||
+_reactive-graph-server__json-schema__help__types_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema help types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__types__components_commands] )) ||
+_reactive-graph-server__json-schema__help__types__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help types components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__types__entities_commands] )) ||
+_reactive-graph-server__json-schema__help__types__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help types entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__types__flows_commands] )) ||
+_reactive-graph-server__json-schema__help__types__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help types flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__help__types__relations_commands] )) ||
+_reactive-graph-server__json-schema__help__types__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema help types relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances_commands] )) ||
+_reactive-graph-server__json-schema__instances_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema instances commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__entities_commands] )) ||
+_reactive-graph-server__json-schema__instances__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__flows_commands] )) ||
+_reactive-graph-server__json-schema__instances__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__help_commands] )) ||
+_reactive-graph-server__json-schema__instances__help_commands() {
+    local commands; commands=(
+'entities:Prints the JSON schema of the entity instances' \
+'relations:Prints the JSON schema of the relation instances' \
+'flows:Prints the JSON schema of the flow instances' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema instances help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__help__entities_commands] )) ||
+_reactive-graph-server__json-schema__instances__help__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances help entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__help__flows_commands] )) ||
+_reactive-graph-server__json-schema__instances__help__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances help flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__help__help_commands] )) ||
+_reactive-graph-server__json-schema__instances__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__help__relations_commands] )) ||
+_reactive-graph-server__json-schema__instances__help__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances help relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__instances__relations_commands] )) ||
+_reactive-graph-server__json-schema__instances__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema instances relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types_commands] )) ||
+_reactive-graph-server__json-schema__types_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema types commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__components_commands] )) ||
+_reactive-graph-server__json-schema__types__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__entities_commands] )) ||
+_reactive-graph-server__json-schema__types__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__flows_commands] )) ||
+_reactive-graph-server__json-schema__types__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__help_commands] )) ||
+_reactive-graph-server__json-schema__types__help_commands() {
+    local commands; commands=(
+'components:Prints the JSON schema of the component types' \
+'entities:Prints the JSON schema of the entity types' \
+'relations:Prints the JSON schema of the relation types' \
+'flows:Prints the JSON schema of the flow types' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'reactive-graph-server json-schema types help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__help__components_commands] )) ||
+_reactive-graph-server__json-schema__types__help__components_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types help components commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__help__entities_commands] )) ||
+_reactive-graph-server__json-schema__types__help__entities_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types help entities commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__help__flows_commands] )) ||
+_reactive-graph-server__json-schema__types__help__flows_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types help flows commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__help__help_commands] )) ||
+_reactive-graph-server__json-schema__types__help__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types help help commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__help__relations_commands] )) ||
+_reactive-graph-server__json-schema__types__help__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types help relations commands' commands "$@"
+}
+(( $+functions[_reactive-graph-server__json-schema__types__relations_commands] )) ||
+_reactive-graph-server__json-schema__types__relations_commands() {
+    local commands; commands=()
+    _describe -t commands 'reactive-graph-server json-schema types relations commands' commands "$@"
 }
 (( $+functions[_reactive-graph-server__man-pages_commands] )) ||
 _reactive-graph-server__man-pages_commands() {
@@ -594,73 +1264,6 @@ _reactive-graph-server__man-pages__print_commands() {
 _reactive-graph-server__print-markdown-help_commands() {
     local commands; commands=()
     _describe -t commands 'reactive-graph-server print-markdown-help commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema_commands] )) ||
-_reactive-graph-server__schema_commands() {
-    local commands; commands=(
-'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
-'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
-'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
-'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
-'help:Print this message or the help of the given subcommand(s)' \
-    )
-    _describe -t commands 'reactive-graph-server schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__dynamic-graph-schema_commands] )) ||
-_reactive-graph-server__schema__dynamic-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema dynamic-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__help_commands] )) ||
-_reactive-graph-server__schema__help_commands() {
-    local commands; commands=(
-'reactive-graph-schema:Prints the GraphQL schema of the reactive graph' \
-'dynamic-graph-schema:Prints the GraphQL schema of the dynamic graph' \
-'reactive-graph-plugin-schema:Prints the GraphQL schema of the plugin system of the reactive graph' \
-'reactive-graph-runtime-schema:Prints the GraphQL schema of the runtime of the reactive graph' \
-'help:Print this message or the help of the given subcommand(s)' \
-    )
-    _describe -t commands 'reactive-graph-server schema help commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__help__dynamic-graph-schema_commands] )) ||
-_reactive-graph-server__schema__help__dynamic-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema help dynamic-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__help__help_commands] )) ||
-_reactive-graph-server__schema__help__help_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema help help commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__help__reactive-graph-plugin-schema_commands] )) ||
-_reactive-graph-server__schema__help__reactive-graph-plugin-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema help reactive-graph-plugin-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__help__reactive-graph-runtime-schema_commands] )) ||
-_reactive-graph-server__schema__help__reactive-graph-runtime-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema help reactive-graph-runtime-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__help__reactive-graph-schema_commands] )) ||
-_reactive-graph-server__schema__help__reactive-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema help reactive-graph-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__reactive-graph-plugin-schema_commands] )) ||
-_reactive-graph-server__schema__reactive-graph-plugin-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema reactive-graph-plugin-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__reactive-graph-runtime-schema_commands] )) ||
-_reactive-graph-server__schema__reactive-graph-runtime-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema reactive-graph-runtime-schema commands' commands "$@"
-}
-(( $+functions[_reactive-graph-server__schema__reactive-graph-schema_commands] )) ||
-_reactive-graph-server__schema__reactive-graph-schema_commands() {
-    local commands; commands=()
-    _describe -t commands 'reactive-graph-server schema reactive-graph-schema commands' commands "$@"
 }
 (( $+functions[_reactive-graph-server__shell-completions_commands] )) ||
 _reactive-graph-server__shell-completions_commands() {

--- a/crates/reactive-graph/src/client/args/connection.rs
+++ b/crates/reactive-graph/src/client/args/connection.rs
@@ -45,9 +45,7 @@ pub struct ClientConnectionArguments {
     ///
     /// Defaults to `false`.
     ///
-    /// Warning:
-    ///
-    /// You should think very carefully before using this method. If
+    /// Warning: You should think very carefully before using this method. If
     /// invalid certificates are trusted, *any* certificate for *any* site
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
@@ -59,9 +57,7 @@ pub struct ClientConnectionArguments {
     ///
     /// Defaults to `false`.
     ///
-    /// Warning
-    ///
-    /// You should think very carefully before you use this method. If
+    /// Warning: You should think very carefully before you use this method. If
     /// hostname verification is not used, any valid certificate for any
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.

--- a/crates/remotes/model/src/instance_address.rs
+++ b/crates/remotes/model/src/instance_address.rs
@@ -62,9 +62,7 @@ pub struct InstanceAddress {
     ///
     /// Defaults to `false`.
     ///
-    /// Warning
-    ///
-    /// You should think very carefully before using this method. If
+    /// Warning: You should think very carefully before using this method. If
     /// invalid certificates are trusted, *any* certificate for *any* site
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
@@ -76,9 +74,7 @@ pub struct InstanceAddress {
     ///
     /// Defaults to `false`.
     ///
-    /// Warning
-    ///
-    /// You should think very carefully before you use this method. If
+    /// Warning: You should think very carefully before you use this method. If
     /// hostname verification is not used, any valid certificate for any
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.

--- a/crates/runtime/graphql/schema/src/instance_address.rs
+++ b/crates/runtime/graphql/schema/src/instance_address.rs
@@ -43,9 +43,7 @@ pub struct InstanceAddressDefinition {
     ///
     /// Defaults to `false`.
     ///
-    /// Warning
-    ///
-    /// You should think very carefully before using this method. If
+    /// Warning: You should think very carefully before using this method. If
     /// invalid certificates are trusted, *any* certificate for *any* site
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
@@ -56,9 +54,7 @@ pub struct InstanceAddressDefinition {
     ///
     /// Defaults to `false`.
     ///
-    /// Warning
-    ///
-    /// You should think very carefully before you use this method. If
+    /// Warning: You should think very carefully before you use this method. If
     /// hostname verification is not used, any valid certificate for any
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  reactive-graph:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # image: ghcr.io/reactive-graph/reactive-graph:latest
+    container_name: reactive-graph
+    volumes:
+      - reactive-graph-plugins-deploy:/opt/reactive-graph/plugins/deploy
+    networks:
+      - reactive-graph-network
+    user: "reactive-graph:reactive-graph"
+    ports:
+      - "31415:31415"
+
+  reactive-graph-plugin-provisioner:
+    image: debian:bookworm-slim
+    container_name: "reactive-graph-plugin-provisioner-${REPOSITORY}-${TAG}"
+    environment:
+      REPOSITORY: "std"
+      TAG: "nightly"
+      FILE_EXTENSION: ".tar.gz"
+    volumes:
+      - reactive-graph-plugins-deploy:/deploy
+    command: >
+      sh -c "
+      addgroup --gid 1000 reactive-graph;
+      useradd -d /deploy -s /bin/bash -g reactive-graph -u 1000 reactive-graph;
+      apt-get update && apt-get install -y --no-install-recommends wget tar dpkg ca-certificates && rm -rf /var/lib/apt/lists/*;
+      echo "REPOSITORY=${REPOSITORY}";
+      echo "TAG=${TAG}";
+      VERSION="$${TAG#v}";
+      echo "VERSION=$${VERSION}";
+      dpkg --print-architecture;
+      DEBIAN_ARCH=$(dpkg --print-architecture);
+      echo "DEBIAN_ARCH=$${DEBIAN_ARCH}";
+      RUST_TARGET_TRIPLE="";
+      if [ "$$DEBIAN_ARCH" = "amd64" ]; then
+        RUST_TARGET_TRIPLE="x86_64-unknown-linux-gnu";
+      elif [ "$$DEBIAN_ARCH" = "i386" ]; then
+        RUST_TARGET_TRIPLE="i686-unknown-linux-gnu";
+      elif [ "$$DEBIAN_ARCH" = "arm64" ]; then
+        RUST_TARGET_TRIPLE="aarch64-unknown-linux-gnu";
+      elif [ "$$DEBIAN_ARCH" = "armhf" ]; then
+        RUST_TARGET_TRIPLE="armv7-unknown-linux-gnueabihf";
+      elif [ "$$DEBIAN_ARCH" = "armel" ]; then
+        RUST_TARGET_TRIPLE="arm-unknown-linux-gnueabi";
+      elif [ "$$DEBIAN_ARCH" = "ppc64el" ]; then
+        RUST_TARGET_TRIPLE="powerpc64le-unknown-linux-gnu";
+      elif [ "$$DEBIAN_ARCH" = "riscv64" ]; then
+        RUST_TARGET_TRIPLE="riscv64gc-unknown-linux-gnu";
+      fi;
+      echo "RUST_TARGET_TRIPLE=$${RUST_TARGET_TRIPLE}";
+      LOCAL_FILENAME="reactive-graph-$${REPOSITORY}_$${VERSION}$${FILE_EXTENSION}";
+      echo "LOCAL_FILENAME=$${LOCAL_FILENAME}";
+      DOWNLOAD_URL="https://github.com/reactive-graph/$${REPOSITORY}/releases/download/$${TAG}/reactive-graph-$${REPOSITORY}_$${VERSION}_$${RUST_TARGET_TRIPLE}$${FILE_EXTENSION}";
+      echo "DOWNLOAD_URL=$${DOWNLOAD_URL}";
+      wget -O "$$LOCAL_FILENAME" "$$DOWNLOAD_URL";
+      TEMP_DIR=$(mktemp -d -t reactive-graph-plugins_XXXXXX);
+      echo "TEMP_DIR=$${TEMP_DIR}";
+      tar -xzf "$$LOCAL_FILENAME" -C "$$TEMP_DIR";
+      chown reactive-graph:reactive-graph "$$TEMP_DIR/*.so";
+      chmod 775 "$$TEMP_DIR/*.so";
+      cp -a "$$TEMP_DIR/*.so" "/deploy/";
+      rm -rf "$$TEMP_DIR";
+      "
+    depends_on:
+      - reactive-graph
+    networks:
+      - reactive-graph-network
+    restart: "no"
+
+volumes:
+  reactive-graph-plugins-deploy:
+    driver: local
+
+networks:
+  reactive-graph-network:
+    driver: bridge

--- a/docs/cli/reference/reactive-graph-client.md
+++ b/docs/cli/reference/reactive-graph-client.md
@@ -41,6 +41,7 @@ This document contains the help content for the `reactive-graph-client` command-
 * [`reactive-graph-client components get`↴](#reactive-graph-client-components-get)
 * [`reactive-graph-client components list-properties`↴](#reactive-graph-client-components-list-properties)
 * [`reactive-graph-client components list-extensions`↴](#reactive-graph-client-components-list-extensions)
+* [`reactive-graph-client components get-json-schema`↴](#reactive-graph-client-components-get-json-schema)
 * [`reactive-graph-client components create`↴](#reactive-graph-client-components-create)
 * [`reactive-graph-client components delete`↴](#reactive-graph-client-components-delete)
 * [`reactive-graph-client components add-property`↴](#reactive-graph-client-components-add-property)
@@ -55,6 +56,7 @@ This document contains the help content for the `reactive-graph-client` command-
 * [`reactive-graph-client entity-types list-properties`↴](#reactive-graph-client-entity-types-list-properties)
 * [`reactive-graph-client entity-types list-extensions`↴](#reactive-graph-client-entity-types-list-extensions)
 * [`reactive-graph-client entity-types list-components`↴](#reactive-graph-client-entity-types-list-components)
+* [`reactive-graph-client entity-types get-json-schema`↴](#reactive-graph-client-entity-types-get-json-schema)
 * [`reactive-graph-client entity-types create`↴](#reactive-graph-client-entity-types-create)
 * [`reactive-graph-client entity-types delete`↴](#reactive-graph-client-entity-types-delete)
 * [`reactive-graph-client entity-types add-property`↴](#reactive-graph-client-entity-types-add-property)
@@ -71,6 +73,7 @@ This document contains the help content for the `reactive-graph-client` command-
 * [`reactive-graph-client relation-types list-properties`↴](#reactive-graph-client-relation-types-list-properties)
 * [`reactive-graph-client relation-types list-extensions`↴](#reactive-graph-client-relation-types-list-extensions)
 * [`reactive-graph-client relation-types list-components`↴](#reactive-graph-client-relation-types-list-components)
+* [`reactive-graph-client relation-types get-json-schema`↴](#reactive-graph-client-relation-types-get-json-schema)
 * [`reactive-graph-client relation-types create`↴](#reactive-graph-client-relation-types-create)
 * [`reactive-graph-client relation-types delete`↴](#reactive-graph-client-relation-types-delete)
 * [`reactive-graph-client relation-types add-property`↴](#reactive-graph-client-relation-types-add-property)
@@ -86,6 +89,7 @@ This document contains the help content for the `reactive-graph-client` command-
 * [`reactive-graph-client flow-types get`↴](#reactive-graph-client-flow-types-get)
 * [`reactive-graph-client flow-types list-variables`↴](#reactive-graph-client-flow-types-list-variables)
 * [`reactive-graph-client flow-types list-extensions`↴](#reactive-graph-client-flow-types-list-extensions)
+* [`reactive-graph-client flow-types get-json-schema`↴](#reactive-graph-client-flow-types-get-json-schema)
 * [`reactive-graph-client flow-types create`↴](#reactive-graph-client-flow-types-create)
 * [`reactive-graph-client flow-types delete`↴](#reactive-graph-client-flow-types-delete)
 * [`reactive-graph-client flow-types add-variable`↴](#reactive-graph-client-flow-types-add-variable)
@@ -142,7 +146,7 @@ This document contains the help content for the `reactive-graph-client` command-
 
 Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 
-**Usage:** `reactive-graph-client [OPTIONS] [COMMAND]`
+**Usage:** `reactive-graph-client [OPTIONS] [DANGER_ACCEPT_INVALID_HOSTNAMES] [COMMAND]`
 
 ###### **Subcommands:**
 
@@ -164,6 +168,17 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 * `flow-instances` — Manage flow instances
 * `introspection` — Execute GraphQL introspection queries
 
+###### **Arguments:**
+
+* `<DANGER_ACCEPT_INVALID_HOSTNAMES>` — Controls the use of hostname verification.
+
+   Defaults to `false`.
+
+   Warning: You should think very carefully before you use this method. If hostname verification is not used, any valid certificate for any site will be trusted for use from any other. This introduces a significant vulnerability to man-in-the-middle attacks.
+
+  Possible values: `true`, `false`
+
+
 ###### **Options:**
 
 * `--client-hostname <CLIENT_HOSTNAME>` — The hostname to connect to
@@ -177,6 +192,16 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 * `--endpoint-runtime <ENDPOINT_RUNTIME>` — The endpoint to use
 * `--endpoint-plugins <ENDPOINT_PLUGINS>` — The endpoint to use
 * `--bearer <BEARER>` — The authentication token
+* `--danger-accept-invalid-certs <DANGER_ACCEPT_INVALID_CERTS>` — Controls the use of certificate validation.
+
+   Defaults to `false`.
+
+   Warning: You should think very carefully before using this method. If invalid certificates are trusted, *any* certificate for *any* site will be trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+
+  Possible values: `true`, `false`
+
+
+
 
 ## `reactive-graph-client shell-completions`
 
@@ -188,6 +213,8 @@ Prints or installs Shell completions
 
 * `print` — Prints the shell completions to stdout
 * `install` — Installs the shell completions
+
+
 
 ## `reactive-graph-client shell-completions print`
 
@@ -201,6 +228,9 @@ Prints the shell completions to stdout
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph-client shell-completions install`
 
 Installs the shell completions
@@ -213,6 +243,9 @@ Installs the shell completions
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph-client man-pages`
 
 Prints or installs man pages
@@ -224,11 +257,15 @@ Prints or installs man pages
 * `print` — Prints the man pages to stdout
 * `install` — Installs the man pages
 
+
+
 ## `reactive-graph-client man-pages print`
 
 Prints the man pages to stdout
 
 **Usage:** `reactive-graph-client man-pages print`
+
+
 
 ## `reactive-graph-client man-pages install`
 
@@ -236,11 +273,15 @@ Installs the man pages
 
 **Usage:** `reactive-graph-client man-pages install`
 
+
+
 ## `reactive-graph-client print-markdown-help`
 
 Prints the markdown help to stdout
 
 **Usage:** `reactive-graph-client print-markdown-help`
+
+
 
 ## `reactive-graph-client info`
 
@@ -254,6 +295,9 @@ Prints info about this binary
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client execute-command`
 
 Executes a command on the client
@@ -265,6 +309,8 @@ Executes a command on the client
 * `<COMMAND_NAME>` — The command name
 * `<COMMAND_ARGUMENTS>` — The command arguments
 
+
+
 ## `reactive-graph-client instance-info`
 
 Prints information about the instance
@@ -275,11 +321,15 @@ Prints information about the instance
 
 * `get` — Get instance information
 
+
+
 ## `reactive-graph-client instance-info get`
 
 Get instance information
 
 **Usage:** `reactive-graph-client instance-info get`
+
+
 
 ## `reactive-graph-client plugins`
 
@@ -299,11 +349,15 @@ Manage plugins
 * `restart` — Restarts a plugin
 * `uninstall` — Uninstall a plugin
 
+
+
 ## `reactive-graph-client plugins list`
 
 Lists all plugins
 
 **Usage:** `reactive-graph-client plugins list`
+
+
 
 ## `reactive-graph-client plugins search`
 
@@ -317,6 +371,8 @@ Search for plugins by name, state or stem
 * `--state <STATE>` — The plugin state
 * `--stem <STEM>` — The plugin file stem
 
+
+
 ## `reactive-graph-client plugins get`
 
 Prints a single plugin
@@ -326,6 +382,8 @@ Prints a single plugin
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph-client plugins dependencies`
 
@@ -337,6 +395,8 @@ Depends on
 
 * `<NAME>` — The plugin name
 
+
+
 ## `reactive-graph-client plugins dependents`
 
 Dependent plugins
@@ -346,6 +406,8 @@ Dependent plugins
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph-client plugins start`
 
@@ -357,6 +419,8 @@ Starts a plugin
 
 * `<NAME>` — The plugin name
 
+
+
 ## `reactive-graph-client plugins stop`
 
 Stops a plugin
@@ -366,6 +430,8 @@ Stops a plugin
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph-client plugins restart`
 
@@ -377,6 +443,8 @@ Restarts a plugin
 
 * `<NAME>` — The plugin name
 
+
+
 ## `reactive-graph-client plugins uninstall`
 
 Uninstall a plugin
@@ -386,6 +454,8 @@ Uninstall a plugin
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph-client remotes`
 
@@ -404,11 +474,15 @@ Manage remotes
 * `fetch-remotes-from-remote` — Fetches the remotes from the given remote
 * `fetch-remotes-from-all-remotes` — Fetches all remotes from all remotes
 
+
+
 ## `reactive-graph-client remotes list`
 
 Lists the remotes
 
 **Usage:** `reactive-graph-client remotes list`
+
+
 
 ## `reactive-graph-client remotes add`
 
@@ -424,6 +498,9 @@ Adds a remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph-client remotes remove`
 
 Removes a remote
@@ -438,11 +515,16 @@ Removes a remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph-client remotes remove-all`
 
 Removes all remotes
 
 **Usage:** `reactive-graph-client remotes remove-all`
+
+
 
 ## `reactive-graph-client remotes update`
 
@@ -458,11 +540,16 @@ Updates a remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph-client remotes update-all`
 
 Updates all remotes
 
 **Usage:** `reactive-graph-client remotes update-all`
+
+
 
 ## `reactive-graph-client remotes fetch-remotes-from-remote`
 
@@ -478,17 +565,24 @@ Fetches the remotes from the given remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph-client remotes fetch-remotes-from-all-remotes`
 
 Fetches all remotes from all remotes
 
 **Usage:** `reactive-graph-client remotes fetch-remotes-from-all-remotes`
 
+
+
 ## `reactive-graph-client shutdown`
 
 Shutdown the runtime
 
 **Usage:** `reactive-graph-client shutdown`
+
+
 
 ## `reactive-graph-client components`
 
@@ -502,6 +596,7 @@ Manage components
 * `get` — Prints a single component
 * `list-properties` — List the properties of a component
 * `list-extensions` — List the extensions of a component
+* `get-json-schema` — Prints the JSON Schema of a component
 * `create` — Creates a new component
 * `delete` — Deletes a component
 * `add-property` — Adds a property to a component
@@ -517,11 +612,16 @@ Manage components
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client components list`
 
 List all components
 
 **Usage:** `reactive-graph-client components list`
+
+
 
 ## `reactive-graph-client components get`
 
@@ -534,6 +634,8 @@ Prints a single component
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 
+
+
 ## `reactive-graph-client components list-properties`
 
 List the properties of a component
@@ -545,6 +647,8 @@ List the properties of a component
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 
+
+
 ## `reactive-graph-client components list-extensions`
 
 List the extensions of a component
@@ -555,6 +659,21 @@ List the extensions of a component
 
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
+
+
+
+## `reactive-graph-client components get-json-schema`
+
+Prints the JSON Schema of a component
+
+**Usage:** `reactive-graph-client components get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The component namespace
+* `<NAME>` — The component name
+
+
 
 ## `reactive-graph-client components create`
 
@@ -568,6 +687,8 @@ Creates a new component
 * `<NAME>` — The component name
 * `<DESCRIPTION>` — The component description
 
+
+
 ## `reactive-graph-client components delete`
 
 Deletes a component
@@ -578,6 +699,8 @@ Deletes a component
 
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
+
+
 
 ## `reactive-graph-client components add-property`
 
@@ -595,6 +718,8 @@ Adds a property to a component
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph-client components remove-property`
 
 Removes a property from a component
@@ -606,6 +731,8 @@ Removes a property from a component
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph-client components add-extension`
 
@@ -622,6 +749,8 @@ Adds an extension to a component
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph-client components remove-extension`
 
 Removes an extension from a component
@@ -635,6 +764,8 @@ Removes an extension from a component
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
 
+
+
 ## `reactive-graph-client components update-description`
 
 Updates the description of a component
@@ -647,11 +778,15 @@ Updates the description of a component
 * `<NAME>` — The component name
 * `<DESCRIPTION>` — The description to update
 
+
+
 ## `reactive-graph-client components json-schema`
 
 Prints the JSON Schema of components
 
 **Usage:** `reactive-graph-client components json-schema`
+
+
 
 ## `reactive-graph-client entity-types`
 
@@ -666,6 +801,7 @@ Manage entity types
 * `list-properties` — List the properties of an entity type
 * `list-extensions` — List the extensions of an entity type
 * `list-components` — List the components of an entity type
+* `get-json-schema` — Prints the JSON Schema of an entity type
 * `create` — Creates a new entity type
 * `delete` — Deletes a entity type
 * `add-property` — Adds a property to an entity type
@@ -683,11 +819,16 @@ Manage entity types
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client entity-types list`
 
 List all entity types
 
 **Usage:** `reactive-graph-client entity-types list`
+
+
 
 ## `reactive-graph-client entity-types get`
 
@@ -700,6 +841,8 @@ Prints a single entity type
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
 
+
+
 ## `reactive-graph-client entity-types list-properties`
 
 List the properties of an entity type
@@ -710,6 +853,8 @@ List the properties of an entity type
 
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
+
+
 
 ## `reactive-graph-client entity-types list-extensions`
 
@@ -722,6 +867,8 @@ List the extensions of an entity type
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
 
+
+
 ## `reactive-graph-client entity-types list-components`
 
 List the components of an entity type
@@ -732,6 +879,21 @@ List the components of an entity type
 
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
+
+
+
+## `reactive-graph-client entity-types get-json-schema`
+
+Prints the JSON Schema of an entity type
+
+**Usage:** `reactive-graph-client entity-types get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The entity type namespace
+* `<NAME>` — The entity type name
+
+
 
 ## `reactive-graph-client entity-types create`
 
@@ -745,6 +907,8 @@ Creates a new entity type
 * `<NAME>` — The entity type name
 * `<DESCRIPTION>` — The entity type description
 
+
+
 ## `reactive-graph-client entity-types delete`
 
 Deletes a entity type
@@ -755,6 +919,8 @@ Deletes a entity type
 
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
+
+
 
 ## `reactive-graph-client entity-types add-property`
 
@@ -772,6 +938,8 @@ Adds a property to an entity type
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph-client entity-types remove-property`
 
 Removes a property from an entity type
@@ -783,6 +951,8 @@ Removes a property from an entity type
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph-client entity-types add-extension`
 
@@ -799,6 +969,8 @@ Adds an extension to an entity type
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph-client entity-types remove-extension`
 
 Removes an extension from an entity type
@@ -811,6 +983,8 @@ Removes an extension from an entity type
 * `<NAME>` — The entity type name
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
+
+
 
 ## `reactive-graph-client entity-types add-component`
 
@@ -825,6 +999,8 @@ Adds a component to an entity type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph-client entity-types remove-component`
 
 Removes a component from an entity type
@@ -838,6 +1014,8 @@ Removes a component from an entity type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph-client entity-types update-description`
 
 Updates the description of an entity type
@@ -850,11 +1028,15 @@ Updates the description of an entity type
 * `<NAME>` — The entity type name
 * `<DESCRIPTION>` — The description to update
 
+
+
 ## `reactive-graph-client entity-types json-schema`
 
 Prints the JSON Schema of entity types
 
 **Usage:** `reactive-graph-client entity-types json-schema`
+
+
 
 ## `reactive-graph-client relation-types`
 
@@ -869,6 +1051,7 @@ Manage entity types
 * `list-properties` — List the properties of an relation type
 * `list-extensions` — List the extensions of an relation type
 * `list-components` — List the components of an relation type
+* `get-json-schema` — Prints the JSON Schema of an relation type
 * `create` — Creates a new relation type
 * `delete` — Deletes a relation type
 * `add-property` — Adds a property to a relation type
@@ -886,11 +1069,16 @@ Manage entity types
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client relation-types list`
 
 List all relation types
 
 **Usage:** `reactive-graph-client relation-types list`
+
+
 
 ## `reactive-graph-client relation-types get`
 
@@ -903,6 +1091,8 @@ Prints a single relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 
+
+
 ## `reactive-graph-client relation-types list-properties`
 
 List the properties of an relation type
@@ -913,6 +1103,8 @@ List the properties of an relation type
 
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
+
+
 
 ## `reactive-graph-client relation-types list-extensions`
 
@@ -925,6 +1117,8 @@ List the extensions of an relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 
+
+
 ## `reactive-graph-client relation-types list-components`
 
 List the components of an relation type
@@ -936,12 +1130,26 @@ List the components of an relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 
+
+
+## `reactive-graph-client relation-types get-json-schema`
+
+Prints the JSON Schema of an relation type
+
+**Usage:** `reactive-graph-client relation-types get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The relation type namespace
+* `<NAME>` — The relation type name
+
+
+
 ## `reactive-graph-client relation-types create`
 
 Creates a new relation type
 
-**Usage:**
-`reactive-graph-client relation-types create <OUTBOUND_TYPE_NAMESPACE> <OUTBOUND_TYPE_NAME> <NAMESPACE> <NAME> <INBOUND_TYPE_NAMESPACE> <INBOUND_TYPE_NAME> [DESCRIPTION]`
+**Usage:** `reactive-graph-client relation-types create <OUTBOUND_TYPE_NAMESPACE> <OUTBOUND_TYPE_NAME> <NAMESPACE> <NAME> <INBOUND_TYPE_NAMESPACE> <INBOUND_TYPE_NAME> [DESCRIPTION]`
 
 ###### **Arguments:**
 
@@ -953,6 +1161,8 @@ Creates a new relation type
 * `<INBOUND_TYPE_NAME>` — The inbound entity type name
 * `<DESCRIPTION>` — The relation type description
 
+
+
 ## `reactive-graph-client relation-types delete`
 
 Deletes a relation type
@@ -963,6 +1173,8 @@ Deletes a relation type
 
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
+
+
 
 ## `reactive-graph-client relation-types add-property`
 
@@ -980,6 +1192,8 @@ Adds a property to a relation type
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph-client relation-types remove-property`
 
 Removes a property from a relation type
@@ -991,6 +1205,8 @@ Removes a property from a relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph-client relation-types add-extension`
 
@@ -1007,6 +1223,8 @@ Adds an extension to a relation type
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph-client relation-types remove-extension`
 
 Removes an extension from a relation type
@@ -1019,6 +1237,8 @@ Removes an extension from a relation type
 * `<NAME>` — The relation type name
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
+
+
 
 ## `reactive-graph-client relation-types add-component`
 
@@ -1033,6 +1253,8 @@ Adds a component to a relation type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph-client relation-types remove-component`
 
 Removes a component from a relation type
@@ -1046,6 +1268,8 @@ Removes a component from a relation type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph-client relation-types update-description`
 
 Updates the description of a relation type
@@ -1058,11 +1282,15 @@ Updates the description of a relation type
 * `<NAME>` — The relation type name
 * `<DESCRIPTION>` — The description to update
 
+
+
 ## `reactive-graph-client relation-types json-schema`
 
 Prints the JSON Schema of relation types
 
 **Usage:** `reactive-graph-client relation-types json-schema`
+
+
 
 ## `reactive-graph-client flow-types`
 
@@ -1076,6 +1304,7 @@ Manage entity types
 * `get` — Prints a single flow type
 * `list-variables` — List the variables of a flow type
 * `list-extensions` — List the extensions of a flow type
+* `get-json-schema` — Prints the JSON Schema of a flow type
 * `create` — Creates a new flow type
 * `delete` — Deletes a flow type
 * `add-variable` — Adds a property to a flow type
@@ -1093,11 +1322,16 @@ Manage entity types
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client flow-types list`
 
 List all flow types
 
 **Usage:** `reactive-graph-client flow-types list`
+
+
 
 ## `reactive-graph-client flow-types get`
 
@@ -1110,6 +1344,8 @@ Prints a single flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 
+
+
 ## `reactive-graph-client flow-types list-variables`
 
 List the variables of a flow type
@@ -1120,6 +1356,8 @@ List the variables of a flow type
 
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
+
+
 
 ## `reactive-graph-client flow-types list-extensions`
 
@@ -1132,12 +1370,26 @@ List the extensions of a flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 
+
+
+## `reactive-graph-client flow-types get-json-schema`
+
+Prints the JSON Schema of a flow type
+
+**Usage:** `reactive-graph-client flow-types get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The flow type namespace
+* `<NAME>` — The flow type name
+
+
+
 ## `reactive-graph-client flow-types create`
 
 Creates a new flow type
 
-**Usage:**
-`reactive-graph-client flow-types create <NAMESPACE> <NAME> <ENTITY_TYPE_NAMESPACE> <ENTITY_TYPE_NAME> <WRAPPER_ENTITY_INSTANCE_ID> [DESCRIPTION] [WRAPPER_ENTITY_INSTANCE_DESCRIPTION]`
+**Usage:** `reactive-graph-client flow-types create <NAMESPACE> <NAME> <ENTITY_TYPE_NAMESPACE> <ENTITY_TYPE_NAME> <WRAPPER_ENTITY_INSTANCE_ID> [DESCRIPTION] [WRAPPER_ENTITY_INSTANCE_DESCRIPTION]`
 
 ###### **Arguments:**
 
@@ -1149,6 +1401,8 @@ Creates a new flow type
 * `<DESCRIPTION>` — The flow type description
 * `<WRAPPER_ENTITY_INSTANCE_DESCRIPTION>` — The description of the wrapper entity instance
 
+
+
 ## `reactive-graph-client flow-types delete`
 
 Deletes a flow type
@@ -1159,6 +1413,8 @@ Deletes a flow type
 
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
+
+
 
 ## `reactive-graph-client flow-types add-variable`
 
@@ -1176,6 +1432,8 @@ Adds a property to a flow type
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph-client flow-types remove-variable`
 
 Removes a property from a flow type
@@ -1187,6 +1445,8 @@ Removes a property from a flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 * `<VARIABLE_NAME>` — The name of the variable
+
+
 
 ## `reactive-graph-client flow-types add-extension`
 
@@ -1203,6 +1463,8 @@ Adds an extension to a flow type
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph-client flow-types remove-extension`
 
 Removes an extension from a flow type
@@ -1216,6 +1478,8 @@ Removes an extension from a flow type
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
 
+
+
 ## `reactive-graph-client flow-types update-description`
 
 Updates the description of a flow type
@@ -1227,6 +1491,8 @@ Updates the description of a flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 * `<DESCRIPTION>` — The description to update
+
+
 
 ## `reactive-graph-client flow-types add-entity-instance`
 
@@ -1247,6 +1513,8 @@ Adds a new entity instance to a flow type
 * `-d`, `--description <DESCRIPTION>` — The entity instance description
 * `-p`, `--properties <PROPERTIES>` — The entity instance properties
 
+
+
 ## `reactive-graph-client flow-types remove-entity-instance`
 
 Removes an entity instance to a flow type
@@ -1259,11 +1527,15 @@ Removes an entity instance to a flow type
 * `<NAME>` — The flow type name
 * `<ID>` — The entity instance to remove from the flow type
 
+
+
 ## `reactive-graph-client flow-types json-schema`
 
 Prints the JSON Schema of flow types
 
 **Usage:** `reactive-graph-client flow-types json-schema`
+
+
 
 ## `reactive-graph-client entity-instances`
 
@@ -1294,6 +1566,9 @@ Manage entity instances
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client entity-instances list`
 
 List all entity instances
@@ -1309,6 +1584,8 @@ List all entity instances
 * `-p`, `--properties <PROPERTIES>` — The properties to search for
 * `-c`, `--components <COMPONENTS>` — The components to search for
 
+
+
 ## `reactive-graph-client entity-instances get`
 
 Prints a single entity instance
@@ -1318,6 +1595,8 @@ Prints a single entity instance
 ###### **Arguments:**
 
 * `<ID>` — The id of the entity instance
+
+
 
 ## `reactive-graph-client entity-instances get-by-label`
 
@@ -1329,6 +1608,8 @@ Prints a single entity instance
 
 * `<LABEL>` — The label of the reactive instance
 
+
+
 ## `reactive-graph-client entity-instances list-properties`
 
 Lists the properties of an entity instance
@@ -1338,6 +1619,8 @@ Lists the properties of an entity instance
 ###### **Arguments:**
 
 * `<ID>` — The id of the entity instance
+
+
 
 ## `reactive-graph-client entity-instances get-property`
 
@@ -1349,6 +1632,8 @@ Prints the value of a property of an entity instance
 
 * `<ID>` — The id of the entity instance
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph-client entity-instances set-property`
 
@@ -1362,7 +1647,9 @@ Sets the value of a property of an entity instance
 * `<NAME>` — The name of the property
 * `<VALUE>` — The new JSON value of the property.
 
-  'true' is boolean true, '"true"' is the string "true"
+   'true' is boolean true, '"true"' is the string "true"
+
+
 
 ## `reactive-graph-client entity-instances add-property`
 
@@ -1379,6 +1666,8 @@ Adds a new property to an entity instance
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph-client entity-instances remove-property`
 
 Removes a property from an entity instance
@@ -1390,6 +1679,8 @@ Removes a property from an entity instance
 * `<ID>` — The id of the entity instance
 * `<PROPERTY_NAME>` — The name of the property
 
+
+
 ## `reactive-graph-client entity-instances list-components`
 
 Lists the components of an entity instance
@@ -1399,6 +1690,8 @@ Lists the components of an entity instance
 ###### **Arguments:**
 
 * `<ID>` — The id of the entity instance
+
+
 
 ## `reactive-graph-client entity-instances add-component`
 
@@ -1412,6 +1705,8 @@ Adds a component to an entity instance
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 
+
+
 ## `reactive-graph-client entity-instances remove-component`
 
 Removes a component from an entity instance
@@ -1423,6 +1718,8 @@ Removes a component from an entity instance
 * `<ID>` — The id of the reactive instance
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
+
+
 
 ## `reactive-graph-client entity-instances create`
 
@@ -1441,6 +1738,8 @@ Creates a new entity type
 * `-d`, `--description <DESCRIPTION>` — The entity instance description
 * `-p`, `--properties <PROPERTIES>` — The entity instance properties
 
+
+
 ## `reactive-graph-client entity-instances delete`
 
 CLI argument which identifies an entity instance by its id
@@ -1451,11 +1750,15 @@ CLI argument which identifies an entity instance by its id
 
 * `<ID>` — The id of the entity instance
 
+
+
 ## `reactive-graph-client entity-instances json-schema`
 
 Prints the JSON Schema of entity instances
 
 **Usage:** `reactive-graph-client entity-instances json-schema`
+
+
 
 ## `reactive-graph-client relation-instances`
 
@@ -1485,6 +1788,9 @@ Manage relation instances
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client relation-instances list`
 
 List all relation instances
@@ -1499,6 +1805,8 @@ List all relation instances
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 * `-p`, `--properties <PROPERTIES>` — The properties to search for
 * `-c`, `--components <COMPONENTS>` — The components to search for
+
+
 
 ## `reactive-graph-client relation-instances get`
 
@@ -1517,6 +1825,8 @@ Prints a single relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances list-properties`
 
 Lists the properties of a relation instance
@@ -1534,12 +1844,13 @@ Lists the properties of a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances get-property`
 
 Prints the value of a property of a relation instance
 
-**Usage:**
-`reactive-graph-client relation-instances get-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
+**Usage:** `reactive-graph-client relation-instances get-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
 
 ###### **Arguments:**
 
@@ -1553,12 +1864,13 @@ Prints the value of a property of a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances set-property`
 
 Sets the value of a property of a relation instance
 
-**Usage:**
-`reactive-graph-client relation-instances set-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <PROPERTY_VALUE>`
+**Usage:** `reactive-graph-client relation-instances set-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <PROPERTY_VALUE>`
 
 ###### **Arguments:**
 
@@ -1568,19 +1880,20 @@ Sets the value of a property of a relation instance
 * `<PROPERTY_NAME>` — The name of the property
 * `<PROPERTY_VALUE>` — The JSON value of the property.
 
-  'true' is boolean true, '"true"' is the string "true"
+   'true' is boolean true, '"true"' is the string "true"
 
 ###### **Options:**
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances add-property`
 
 Adds a new property to a relation instance
 
-**Usage:**
-`reactive-graph-client relation-instances add-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]`
+**Usage:** `reactive-graph-client relation-instances add-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]`
 
 ###### **Arguments:**
 
@@ -1598,12 +1911,13 @@ Adds a new property to a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances remove-property`
 
 Removes a property from a relation instance
 
-**Usage:**
-`reactive-graph-client relation-instances remove-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
+**Usage:** `reactive-graph-client relation-instances remove-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
 
 ###### **Arguments:**
 
@@ -1616,6 +1930,8 @@ Removes a property from a relation instance
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
+
+
 
 ## `reactive-graph-client relation-instances list-components`
 
@@ -1634,12 +1950,13 @@ Lists the components of a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances add-component`
 
 Adds a component to a relation instance
 
-**Usage:**
-`reactive-graph-client relation-instances add-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
+**Usage:** `reactive-graph-client relation-instances add-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
 
 ###### **Arguments:**
 
@@ -1653,13 +1970,14 @@ Adds a component to a relation instance
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
+
+
 
 ## `reactive-graph-client relation-instances remove-component`
 
 Removes a component from a relation instance
 
-**Usage:**
-`reactive-graph-client relation-instances remove-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
+**Usage:** `reactive-graph-client relation-instances remove-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
 
 ###### **Arguments:**
 
@@ -1673,6 +1991,8 @@ Removes a component from a relation instance
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
+
+
 
 ## `reactive-graph-client relation-instances create`
 
@@ -1693,6 +2013,8 @@ Creates a new relation type
 * `-d`, `--description <DESCRIPTION>` — The relation instance description
 * `-p`, `--properties <PROPERTIES>` — The relation instance properties
 
+
+
 ## `reactive-graph-client relation-instances delete`
 
 CLI argument which identifies an relation instance by its id
@@ -1710,11 +2032,15 @@ CLI argument which identifies an relation instance by its id
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph-client relation-instances json-schema`
 
 Prints the JSON Schema of relation instances
 
 **Usage:** `reactive-graph-client relation-instances json-schema`
+
+
 
 ## `reactive-graph-client flow-instances`
 
@@ -1737,6 +2063,9 @@ Manage flow instances
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph-client flow-instances list`
 
 List all flow instances
@@ -1750,6 +2079,8 @@ List all flow instances
 * `-i`, `--id <ID>` — The id of the entity instance
 * `-l`, `--label <LABEL>` — The label of the entity instance
 
+
+
 ## `reactive-graph-client flow-instances get`
 
 Prints a single flow instance
@@ -1760,6 +2091,8 @@ Prints a single flow instance
 
 * `<ID>` — The id of the flow instance
 
+
+
 ## `reactive-graph-client flow-instances get-by-label`
 
 Prints a single flow instance
@@ -1769,6 +2102,8 @@ Prints a single flow instance
 ###### **Arguments:**
 
 * `<LABEL>` — The label of the reactive instance
+
+
 
 ## `reactive-graph-client flow-instances create-from-type`
 
@@ -1787,6 +2122,8 @@ Creates a new flow from the given type
 * `-v`, `--variables <VARIABLES>` — The entity instance properties
 * `-p`, `--properties <PROPERTIES>` — The entity instance properties
 
+
+
 ## `reactive-graph-client flow-instances delete`
 
 CLI argument which identifies a flow instance by its id
@@ -1797,11 +2134,15 @@ CLI argument which identifies a flow instance by its id
 
 * `<ID>` — The id of the flow instance
 
+
+
 ## `reactive-graph-client flow-instances json-schema`
 
 Prints the JSON Schema of flow instances
 
 **Usage:** `reactive-graph-client flow-instances json-schema`
+
+
 
 ## `reactive-graph-client introspection`
 
@@ -1816,11 +2157,15 @@ Execute GraphQL introspection queries
 * `reactive-graph-runtime` — Get the GraphQL schema of the reactive graph runtime
 * `reactive-graph-plugins` — Get the GraphQL schema of the plugin system of reactive graph
 
+
+
 ## `reactive-graph-client introspection reactive-graph`
 
 Get the GraphQL schema of the reactive graph
 
 **Usage:** `reactive-graph-client introspection reactive-graph`
+
+
 
 ## `reactive-graph-client introspection dynamic-graph`
 
@@ -1828,11 +2173,15 @@ Get the GraphQL schema of the dynamic graph
 
 **Usage:** `reactive-graph-client introspection dynamic-graph`
 
+
+
 ## `reactive-graph-client introspection reactive-graph-runtime`
 
 Get the GraphQL schema of the reactive graph runtime
 
 **Usage:** `reactive-graph-client introspection reactive-graph-runtime`
+
+
 
 ## `reactive-graph-client introspection reactive-graph-plugins`
 
@@ -1845,6 +2194,7 @@ Get the GraphQL schema of the plugin system of reactive graph
 <hr/>
 
 <small><i>
-This document was generated automatically by
-<a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/docs/cli/reference/reactive-graph-server.md
+++ b/docs/cli/reference/reactive-graph-server.md
@@ -62,8 +62,7 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 
 * `--ssl-certificate-path <SSL_CERTIFICATE_PATH>` — The location of the certificate
 * `--ssl-private-key-path <SSL_PRIVATE_KEY_PATH>` — The location of the private key
-* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to
-  finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
+* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
 * `-w`, `--workers <WORKERS>` — The number of workers to start. The default worker count is the number of physical CPU cores available
 * `-c`, `--default-context-path <DEFAULT_CONTEXT_PATH>` — The default context path which redirects the root context to a web resource provider
 * `-x`, `--disable-all-plugins <DISABLE_ALL_PLUGINS>` — If true, all plugins will be disabled
@@ -86,6 +85,9 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph-server shell-completions`
 
 Prints or installs Shell completions
@@ -96,6 +98,8 @@ Prints or installs Shell completions
 
 * `print` — Prints the shell completions to stdout
 * `install` — Installs the shell completions
+
+
 
 ## `reactive-graph-server shell-completions print`
 
@@ -109,6 +113,9 @@ Prints the shell completions to stdout
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph-server shell-completions install`
 
 Installs the shell completions
@@ -121,6 +128,9 @@ Installs the shell completions
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph-server man-pages`
 
 Prints or installs man pages
@@ -132,11 +142,15 @@ Prints or installs man pages
 * `print` — Prints the man pages to stdout
 * `install` — Installs the man pages
 
+
+
 ## `reactive-graph-server man-pages print`
 
 Prints the man pages to stdout
 
 **Usage:** `reactive-graph-server man-pages print`
+
+
 
 ## `reactive-graph-server man-pages install`
 
@@ -144,11 +158,15 @@ Installs the man pages
 
 **Usage:** `reactive-graph-server man-pages install`
 
+
+
 ## `reactive-graph-server print-markdown-help`
 
 Prints the markdown help to stdout
 
 **Usage:** `reactive-graph-server print-markdown-help`
+
+
 
 ## `reactive-graph-server info`
 
@@ -161,6 +179,9 @@ Prints info about this binary
 * `--output-format <OUTPUT_FORMAT>` — The output format
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
+
+
+
 
 ## `reactive-graph-server daemon`
 
@@ -178,6 +199,8 @@ Runs the server as daemon
 * `--daemon-user <DAEMON_USER>` — If set will drop privileges to the specified user. Note: Both must be given: user and group
 * `--daemon-group <DAEMON_GROUP>` — If set will drop privileges to the specified group. Note: Both must be given: user and group
 
+
+
 ## `reactive-graph-server graphql-schema`
 
 Prints the GraphQL schema and exits
@@ -191,11 +214,15 @@ Prints the GraphQL schema and exits
 * `reactive-graph-plugin-schema` — Prints the GraphQL schema of the plugin system of the reactive graph
 * `reactive-graph-runtime-schema` — Prints the GraphQL schema of the runtime of the reactive graph
 
+
+
 ## `reactive-graph-server graphql-schema reactive-graph-schema`
 
 Prints the GraphQL schema of the reactive graph
 
 **Usage:** `reactive-graph-server graphql-schema reactive-graph-schema`
+
+
 
 ## `reactive-graph-server graphql-schema dynamic-graph-schema`
 
@@ -203,17 +230,23 @@ Prints the GraphQL schema of the dynamic graph
 
 **Usage:** `reactive-graph-server graphql-schema dynamic-graph-schema`
 
+
+
 ## `reactive-graph-server graphql-schema reactive-graph-plugin-schema`
 
 Prints the GraphQL schema of the plugin system of the reactive graph
 
 **Usage:** `reactive-graph-server graphql-schema reactive-graph-plugin-schema`
 
+
+
 ## `reactive-graph-server graphql-schema reactive-graph-runtime-schema`
 
 Prints the GraphQL schema of the runtime of the reactive graph
 
 **Usage:** `reactive-graph-server graphql-schema reactive-graph-runtime-schema`
+
+
 
 ## `reactive-graph-server json-schema`
 
@@ -225,6 +258,8 @@ Prints the JSON schema and exits
 
 * `types` — Prints the JSON schema of the type system
 * `instances` — Prints the JSON schema of the instance system
+
+
 
 ## `reactive-graph-server json-schema types`
 
@@ -239,11 +274,15 @@ Prints the JSON schema of the type system
 * `relations` — Prints the JSON schema of the relation types
 * `flows` — Prints the JSON schema of the flow types
 
+
+
 ## `reactive-graph-server json-schema types components`
 
 Prints the JSON schema of the component types
 
 **Usage:** `reactive-graph-server json-schema types components`
+
+
 
 ## `reactive-graph-server json-schema types entities`
 
@@ -251,17 +290,23 @@ Prints the JSON schema of the entity types
 
 **Usage:** `reactive-graph-server json-schema types entities`
 
+
+
 ## `reactive-graph-server json-schema types relations`
 
 Prints the JSON schema of the relation types
 
 **Usage:** `reactive-graph-server json-schema types relations`
 
+
+
 ## `reactive-graph-server json-schema types flows`
 
 Prints the JSON schema of the flow types
 
 **Usage:** `reactive-graph-server json-schema types flows`
+
+
 
 ## `reactive-graph-server json-schema instances`
 
@@ -275,17 +320,23 @@ Prints the JSON schema of the instance system
 * `relations` — Prints the JSON schema of the relation instances
 * `flows` — Prints the JSON schema of the flow instances
 
+
+
 ## `reactive-graph-server json-schema instances entities`
 
 Prints the JSON schema of the entity instances
 
 **Usage:** `reactive-graph-server json-schema instances entities`
 
+
+
 ## `reactive-graph-server json-schema instances relations`
 
 Prints the JSON schema of the relation instances
 
 **Usage:** `reactive-graph-server json-schema instances relations`
+
+
 
 ## `reactive-graph-server json-schema instances flows`
 
@@ -298,6 +349,7 @@ Prints the JSON schema of the flow instances
 <hr/>
 
 <small><i>
-This document was generated automatically by
-<a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/docs/cli/reference/reactive-graph-tooling.md
+++ b/docs/cli/reference/reactive-graph-tooling.md
@@ -45,6 +45,8 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 * `instances` — Manage instances
 * `update` — Update the Reactive Graph binary
 
+
+
 ## `reactive-graph-tooling shell-completions`
 
 Prints or installs Shell completions
@@ -55,6 +57,8 @@ Prints or installs Shell completions
 
 * `print` — Prints the shell completions to stdout
 * `install` — Installs the shell completions
+
+
 
 ## `reactive-graph-tooling shell-completions print`
 
@@ -68,6 +72,9 @@ Prints the shell completions to stdout
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph-tooling shell-completions install`
 
 Installs the shell completions
@@ -80,6 +87,9 @@ Installs the shell completions
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph-tooling man-pages`
 
 Prints or installs man pages
@@ -91,11 +101,15 @@ Prints or installs man pages
 * `print` — Prints the man pages to stdout
 * `install` — Installs the man pages
 
+
+
 ## `reactive-graph-tooling man-pages print`
 
 Prints the man pages to stdout
 
 **Usage:** `reactive-graph-tooling man-pages print`
+
+
 
 ## `reactive-graph-tooling man-pages install`
 
@@ -103,11 +117,15 @@ Installs the man pages
 
 **Usage:** `reactive-graph-tooling man-pages install`
 
+
+
 ## `reactive-graph-tooling print-markdown-help`
 
 Prints the markdown help to stdout
 
 **Usage:** `reactive-graph-tooling print-markdown-help`
+
+
 
 ## `reactive-graph-tooling info`
 
@@ -120,6 +138,9 @@ Prints info about this binary
 * `--output-format <OUTPUT_FORMAT>` — The output format
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
+
+
+
 
 ## `reactive-graph-tooling instances`
 
@@ -139,6 +160,8 @@ Manage instances
 
 * `<WORKING_DIRECTORY>` — The working directory of the instance. Defaults to the current directory
 
+
+
 ## `reactive-graph-tooling instances config`
 
 Configures a local instance,
@@ -150,6 +173,8 @@ Configures a local instance,
 * `graphql` — Configures the GraphQL server
 * `instance` — Configures the instance
 * `plugins` — Configures the instance
+
+
 
 ## `reactive-graph-tooling instances config graphql`
 
@@ -167,10 +192,11 @@ Configures the GraphQL server
 
 * `--ssl-certificate-path <SSL_CERTIFICATE_PATH>` — The location of the certificate
 * `--ssl-private-key-path <SSL_PRIVATE_KEY_PATH>` — The location of the private key
-* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to
-  finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
+* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
 * `-w`, `--workers <WORKERS>` — The number of workers to start. The default worker count is the number of physical CPU cores available
 * `-c`, `--default-context-path <DEFAULT_CONTEXT_PATH>` — The default context path which redirects the root context to a web resource provider
+
+
 
 ## `reactive-graph-tooling instances config instance`
 
@@ -182,6 +208,8 @@ Configures the instance
 
 * `-n`, `--instance-name <NAME>` — The name of the instance
 * `-d`, `--instance-description <DESCRIPTION>` — The description of the instance
+
+
 
 ## `reactive-graph-tooling instances config plugins`
 
@@ -204,6 +232,8 @@ Configures the instance
 * `--hot-deploy-location <HOT_DEPLOY_LOCATION>` — The folder which is watched for hot deployment
 * `--install-location <INSTALL_LOCATION>` — The folder which plugins are installed permanently
 
+
+
 ## `reactive-graph-tooling instances generate-certificate`
 
 Generates certificate of a local instance
@@ -215,6 +245,8 @@ Generates certificate of a local instance
 * `<COUNTRY_NAME>` — Country name
 * `<ORGANIZATION_NAME>` — Organization name
 * `<COMMON_NAME>` — Common name
+
+
 
 ## `reactive-graph-tooling instances init`
 
@@ -233,6 +265,8 @@ Initialize the filesystem structure of a new local instance
 * `--uid <UID>` — The numeric user id of the owner user
 * `--gid <GID>` — The numeric group id of the owner group
 
+
+
 ## `reactive-graph-tooling instances plugins`
 
 Manage the plugins of a local instance
@@ -244,6 +278,8 @@ Manage the plugins of a local instance
 * `install` — Installs a plugin
 * `uninstall` — Uninstalls a plugin
 
+
+
 ## `reactive-graph-tooling instances plugins install`
 
 Installs a plugin
@@ -253,6 +289,8 @@ Installs a plugin
 ###### **Arguments:**
 
 * `<PLUGIN_NAME>` — The name of the plugin
+
+
 
 ## `reactive-graph-tooling instances plugins uninstall`
 
@@ -264,6 +302,8 @@ Uninstalls a plugin
 
 * `<PLUGIN_NAME>` — The name of the plugin
 
+
+
 ## `reactive-graph-tooling instances repository`
 
 Manage the repositories of a local instance
@@ -274,6 +314,8 @@ Manage the repositories of a local instance
 
 * `init` — Initializes a new local repository in a local instance
 * `remove` — Removes a local repository
+
+
 
 ## `reactive-graph-tooling instances repository init`
 
@@ -291,6 +333,8 @@ Initializes a new local repository in a local instance
 * `--uid <UID>` — The numeric user id of the owner user
 * `--gid <GID>` — The numeric group id of the owner group
 
+
+
 ## `reactive-graph-tooling instances repository remove`
 
 Removes a local repository
@@ -303,6 +347,9 @@ Removes a local repository
 * `<FORCE>` — If true, the default repository will be deleted
 
   Possible values: `true`, `false`
+
+
+
 
 ## `reactive-graph-tooling update`
 
@@ -326,6 +373,8 @@ Update the Reactive Graph binary
 * `-q`, `--quiet` — Hides the download progress and the output
 * `-y`, `--no-confirm` — Don't ask
 
+
+
 ## `reactive-graph-tooling update info`
 
 Shows information about the selected release
@@ -337,6 +386,9 @@ Shows information about the selected release
 * `--output-format <OUTPUT_FORMAT>` — The output format
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
+
+
+
 
 ## `reactive-graph-tooling update list`
 
@@ -350,9 +402,13 @@ Lists the releases
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 <hr/>
 
 <small><i>
-This document was generated automatically by
-<a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/docs/cli/reference/reactive-graph.md
+++ b/docs/cli/reference/reactive-graph.md
@@ -57,6 +57,7 @@ This document contains the help content for the `reactive-graph` command-line pr
 * [`reactive-graph components get`↴](#reactive-graph-components-get)
 * [`reactive-graph components list-properties`↴](#reactive-graph-components-list-properties)
 * [`reactive-graph components list-extensions`↴](#reactive-graph-components-list-extensions)
+* [`reactive-graph components get-json-schema`↴](#reactive-graph-components-get-json-schema)
 * [`reactive-graph components create`↴](#reactive-graph-components-create)
 * [`reactive-graph components delete`↴](#reactive-graph-components-delete)
 * [`reactive-graph components add-property`↴](#reactive-graph-components-add-property)
@@ -71,6 +72,7 @@ This document contains the help content for the `reactive-graph` command-line pr
 * [`reactive-graph entity-types list-properties`↴](#reactive-graph-entity-types-list-properties)
 * [`reactive-graph entity-types list-extensions`↴](#reactive-graph-entity-types-list-extensions)
 * [`reactive-graph entity-types list-components`↴](#reactive-graph-entity-types-list-components)
+* [`reactive-graph entity-types get-json-schema`↴](#reactive-graph-entity-types-get-json-schema)
 * [`reactive-graph entity-types create`↴](#reactive-graph-entity-types-create)
 * [`reactive-graph entity-types delete`↴](#reactive-graph-entity-types-delete)
 * [`reactive-graph entity-types add-property`↴](#reactive-graph-entity-types-add-property)
@@ -87,6 +89,7 @@ This document contains the help content for the `reactive-graph` command-line pr
 * [`reactive-graph relation-types list-properties`↴](#reactive-graph-relation-types-list-properties)
 * [`reactive-graph relation-types list-extensions`↴](#reactive-graph-relation-types-list-extensions)
 * [`reactive-graph relation-types list-components`↴](#reactive-graph-relation-types-list-components)
+* [`reactive-graph relation-types get-json-schema`↴](#reactive-graph-relation-types-get-json-schema)
 * [`reactive-graph relation-types create`↴](#reactive-graph-relation-types-create)
 * [`reactive-graph relation-types delete`↴](#reactive-graph-relation-types-delete)
 * [`reactive-graph relation-types add-property`↴](#reactive-graph-relation-types-add-property)
@@ -102,6 +105,7 @@ This document contains the help content for the `reactive-graph` command-line pr
 * [`reactive-graph flow-types get`↴](#reactive-graph-flow-types-get)
 * [`reactive-graph flow-types list-variables`↴](#reactive-graph-flow-types-list-variables)
 * [`reactive-graph flow-types list-extensions`↴](#reactive-graph-flow-types-list-extensions)
+* [`reactive-graph flow-types get-json-schema`↴](#reactive-graph-flow-types-get-json-schema)
 * [`reactive-graph flow-types create`↴](#reactive-graph-flow-types-create)
 * [`reactive-graph flow-types delete`↴](#reactive-graph-flow-types-delete)
 * [`reactive-graph flow-types add-variable`↴](#reactive-graph-flow-types-add-variable)
@@ -174,7 +178,7 @@ This document contains the help content for the `reactive-graph` command-line pr
 
 Reactive Graph is a reactive runtime based on a graph database, empowering everyone to build reliable and efficient software.
 
-**Usage:** `reactive-graph [OPTIONS] [COMMAND]`
+**Usage:** `reactive-graph [OPTIONS] [DANGER_ACCEPT_INVALID_HOSTNAMES] [COMMAND]`
 
 ###### **Subcommands:**
 
@@ -201,6 +205,17 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 * `instances` — Manage instances
 * `update` — Update the Reactive Graph binary
 
+###### **Arguments:**
+
+* `<DANGER_ACCEPT_INVALID_HOSTNAMES>` — Controls the use of hostname verification.
+
+   Defaults to `false`.
+
+   Warning: You should think very carefully before you use this method. If hostname verification is not used, any valid certificate for any site will be trusted for use from any other. This introduces a significant vulnerability to man-in-the-middle attacks.
+
+  Possible values: `true`, `false`
+
+
 ###### **Options:**
 
 * `--logging-config <LOGGING_CONFIG>` — The logging config location
@@ -217,8 +232,7 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 
 * `--ssl-certificate-path <SSL_CERTIFICATE_PATH>` — The location of the certificate
 * `--ssl-private-key-path <SSL_PRIVATE_KEY_PATH>` — The location of the private key
-* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to
-  finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
+* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
 * `-w`, `--workers <WORKERS>` — The number of workers to start. The default worker count is the number of physical CPU cores available
 * `-c`, `--default-context-path <DEFAULT_CONTEXT_PATH>` — The default context path which redirects the root context to a web resource provider
 * `-x`, `--disable-all-plugins <DISABLE_ALL_PLUGINS>` — If true, all plugins will be disabled
@@ -252,7 +266,17 @@ Reactive Graph is a reactive runtime based on a graph database, empowering every
 * `--endpoint-runtime <ENDPOINT_RUNTIME>` — The endpoint to use
 * `--endpoint-plugins <ENDPOINT_PLUGINS>` — The endpoint to use
 * `--bearer <BEARER>` — The authentication token
+* `--danger-accept-invalid-certs <DANGER_ACCEPT_INVALID_CERTS>` — Controls the use of certificate validation.
+
+   Defaults to `false`.
+
+   Warning: You should think very carefully before using this method. If invalid certificates are trusted, *any* certificate for *any* site will be trusted for use. This includes expired certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+
+  Possible values: `true`, `false`
+
 * `-i`, `--interactive` — Enter the interactive client mode
+
+
 
 ## `reactive-graph shell-completions`
 
@@ -264,6 +288,8 @@ Prints or installs Shell completions
 
 * `print` — Prints the shell completions to stdout
 * `install` — Installs the shell completions
+
+
 
 ## `reactive-graph shell-completions print`
 
@@ -277,6 +303,9 @@ Prints the shell completions to stdout
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph shell-completions install`
 
 Installs the shell completions
@@ -289,6 +318,9 @@ Installs the shell completions
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
+
+
+
 ## `reactive-graph man-pages`
 
 Prints or installs man pages
@@ -300,11 +332,15 @@ Prints or installs man pages
 * `print` — Prints the man pages to stdout
 * `install` — Installs the man pages
 
+
+
 ## `reactive-graph man-pages print`
 
 Prints the man pages to stdout
 
 **Usage:** `reactive-graph man-pages print`
+
+
 
 ## `reactive-graph man-pages install`
 
@@ -312,11 +348,15 @@ Installs the man pages
 
 **Usage:** `reactive-graph man-pages install`
 
+
+
 ## `reactive-graph print-markdown-help`
 
 Prints the markdown help to stdout
 
 **Usage:** `reactive-graph print-markdown-help`
+
+
 
 ## `reactive-graph info`
 
@@ -329,6 +369,9 @@ Prints info about this binary
 * `--output-format <OUTPUT_FORMAT>` — The output format
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
+
+
+
 
 ## `reactive-graph daemon`
 
@@ -346,6 +389,8 @@ Runs the server as daemon
 * `--daemon-user <DAEMON_USER>` — If set will drop privileges to the specified user. Note: Both must be given: user and group
 * `--daemon-group <DAEMON_GROUP>` — If set will drop privileges to the specified group. Note: Both must be given: user and group
 
+
+
 ## `reactive-graph graphql-schema`
 
 Prints the GraphQL schema and exits
@@ -359,11 +404,15 @@ Prints the GraphQL schema and exits
 * `reactive-graph-plugin-schema` — Prints the GraphQL schema of the plugin system of the reactive graph
 * `reactive-graph-runtime-schema` — Prints the GraphQL schema of the runtime of the reactive graph
 
+
+
 ## `reactive-graph graphql-schema reactive-graph-schema`
 
 Prints the GraphQL schema of the reactive graph
 
 **Usage:** `reactive-graph graphql-schema reactive-graph-schema`
+
+
 
 ## `reactive-graph graphql-schema dynamic-graph-schema`
 
@@ -371,17 +420,23 @@ Prints the GraphQL schema of the dynamic graph
 
 **Usage:** `reactive-graph graphql-schema dynamic-graph-schema`
 
+
+
 ## `reactive-graph graphql-schema reactive-graph-plugin-schema`
 
 Prints the GraphQL schema of the plugin system of the reactive graph
 
 **Usage:** `reactive-graph graphql-schema reactive-graph-plugin-schema`
 
+
+
 ## `reactive-graph graphql-schema reactive-graph-runtime-schema`
 
 Prints the GraphQL schema of the runtime of the reactive graph
 
 **Usage:** `reactive-graph graphql-schema reactive-graph-runtime-schema`
+
+
 
 ## `reactive-graph json-schema`
 
@@ -393,6 +448,8 @@ Prints the JSON schema and exits
 
 * `types` — Prints the JSON schema of the type system
 * `instances` — Prints the JSON schema of the instance system
+
+
 
 ## `reactive-graph json-schema types`
 
@@ -407,11 +464,15 @@ Prints the JSON schema of the type system
 * `relations` — Prints the JSON schema of the relation types
 * `flows` — Prints the JSON schema of the flow types
 
+
+
 ## `reactive-graph json-schema types components`
 
 Prints the JSON schema of the component types
 
 **Usage:** `reactive-graph json-schema types components`
+
+
 
 ## `reactive-graph json-schema types entities`
 
@@ -419,17 +480,23 @@ Prints the JSON schema of the entity types
 
 **Usage:** `reactive-graph json-schema types entities`
 
+
+
 ## `reactive-graph json-schema types relations`
 
 Prints the JSON schema of the relation types
 
 **Usage:** `reactive-graph json-schema types relations`
 
+
+
 ## `reactive-graph json-schema types flows`
 
 Prints the JSON schema of the flow types
 
 **Usage:** `reactive-graph json-schema types flows`
+
+
 
 ## `reactive-graph json-schema instances`
 
@@ -443,11 +510,15 @@ Prints the JSON schema of the instance system
 * `relations` — Prints the JSON schema of the relation instances
 * `flows` — Prints the JSON schema of the flow instances
 
+
+
 ## `reactive-graph json-schema instances entities`
 
 Prints the JSON schema of the entity instances
 
 **Usage:** `reactive-graph json-schema instances entities`
+
+
 
 ## `reactive-graph json-schema instances relations`
 
@@ -455,11 +526,15 @@ Prints the JSON schema of the relation instances
 
 **Usage:** `reactive-graph json-schema instances relations`
 
+
+
 ## `reactive-graph json-schema instances flows`
 
 Prints the JSON schema of the flow instances
 
 **Usage:** `reactive-graph json-schema instances flows`
+
+
 
 ## `reactive-graph execute-command`
 
@@ -472,6 +547,8 @@ Executes a command on the client
 * `<COMMAND_NAME>` — The command name
 * `<COMMAND_ARGUMENTS>` — The command arguments
 
+
+
 ## `reactive-graph instance-info`
 
 Prints information about the instance
@@ -482,11 +559,15 @@ Prints information about the instance
 
 * `get` — Get instance information
 
+
+
 ## `reactive-graph instance-info get`
 
 Get instance information
 
 **Usage:** `reactive-graph instance-info get`
+
+
 
 ## `reactive-graph plugins`
 
@@ -506,11 +587,15 @@ Manage plugins
 * `restart` — Restarts a plugin
 * `uninstall` — Uninstall a plugin
 
+
+
 ## `reactive-graph plugins list`
 
 Lists all plugins
 
 **Usage:** `reactive-graph plugins list`
+
+
 
 ## `reactive-graph plugins search`
 
@@ -524,6 +609,8 @@ Search for plugins by name, state or stem
 * `--state <STATE>` — The plugin state
 * `--stem <STEM>` — The plugin file stem
 
+
+
 ## `reactive-graph plugins get`
 
 Prints a single plugin
@@ -533,6 +620,8 @@ Prints a single plugin
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph plugins dependencies`
 
@@ -544,6 +633,8 @@ Depends on
 
 * `<NAME>` — The plugin name
 
+
+
 ## `reactive-graph plugins dependents`
 
 Dependent plugins
@@ -553,6 +644,8 @@ Dependent plugins
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph plugins start`
 
@@ -564,6 +657,8 @@ Starts a plugin
 
 * `<NAME>` — The plugin name
 
+
+
 ## `reactive-graph plugins stop`
 
 Stops a plugin
@@ -573,6 +668,8 @@ Stops a plugin
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph plugins restart`
 
@@ -584,6 +681,8 @@ Restarts a plugin
 
 * `<NAME>` — The plugin name
 
+
+
 ## `reactive-graph plugins uninstall`
 
 Uninstall a plugin
@@ -593,6 +692,8 @@ Uninstall a plugin
 ###### **Arguments:**
 
 * `<NAME>` — The plugin name
+
+
 
 ## `reactive-graph remotes`
 
@@ -611,11 +712,15 @@ Manage remotes
 * `fetch-remotes-from-remote` — Fetches the remotes from the given remote
 * `fetch-remotes-from-all-remotes` — Fetches all remotes from all remotes
 
+
+
 ## `reactive-graph remotes list`
 
 Lists the remotes
 
 **Usage:** `reactive-graph remotes list`
+
+
 
 ## `reactive-graph remotes add`
 
@@ -631,6 +736,9 @@ Adds a remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph remotes remove`
 
 Removes a remote
@@ -645,11 +753,16 @@ Removes a remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph remotes remove-all`
 
 Removes all remotes
 
 **Usage:** `reactive-graph remotes remove-all`
+
+
 
 ## `reactive-graph remotes update`
 
@@ -665,11 +778,16 @@ Updates a remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph remotes update-all`
 
 Updates all remotes
 
 **Usage:** `reactive-graph remotes update-all`
+
+
 
 ## `reactive-graph remotes fetch-remotes-from-remote`
 
@@ -685,17 +803,24 @@ Fetches the remotes from the given remote
 
   Possible values: `true`, `false`
 
+
+
+
 ## `reactive-graph remotes fetch-remotes-from-all-remotes`
 
 Fetches all remotes from all remotes
 
 **Usage:** `reactive-graph remotes fetch-remotes-from-all-remotes`
 
+
+
 ## `reactive-graph shutdown`
 
 Shutdown the runtime
 
 **Usage:** `reactive-graph shutdown`
+
+
 
 ## `reactive-graph components`
 
@@ -709,6 +834,7 @@ Manage components
 * `get` — Prints a single component
 * `list-properties` — List the properties of a component
 * `list-extensions` — List the extensions of a component
+* `get-json-schema` — Prints the JSON Schema of a component
 * `create` — Creates a new component
 * `delete` — Deletes a component
 * `add-property` — Adds a property to a component
@@ -724,11 +850,16 @@ Manage components
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph components list`
 
 List all components
 
 **Usage:** `reactive-graph components list`
+
+
 
 ## `reactive-graph components get`
 
@@ -741,6 +872,8 @@ Prints a single component
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 
+
+
 ## `reactive-graph components list-properties`
 
 List the properties of a component
@@ -752,6 +885,8 @@ List the properties of a component
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 
+
+
 ## `reactive-graph components list-extensions`
 
 List the extensions of a component
@@ -762,6 +897,21 @@ List the extensions of a component
 
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
+
+
+
+## `reactive-graph components get-json-schema`
+
+Prints the JSON Schema of a component
+
+**Usage:** `reactive-graph components get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The component namespace
+* `<NAME>` — The component name
+
+
 
 ## `reactive-graph components create`
 
@@ -775,6 +925,8 @@ Creates a new component
 * `<NAME>` — The component name
 * `<DESCRIPTION>` — The component description
 
+
+
 ## `reactive-graph components delete`
 
 Deletes a component
@@ -785,6 +937,8 @@ Deletes a component
 
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
+
+
 
 ## `reactive-graph components add-property`
 
@@ -802,6 +956,8 @@ Adds a property to a component
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph components remove-property`
 
 Removes a property from a component
@@ -813,6 +969,8 @@ Removes a property from a component
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph components add-extension`
 
@@ -829,6 +987,8 @@ Adds an extension to a component
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph components remove-extension`
 
 Removes an extension from a component
@@ -842,6 +1002,8 @@ Removes an extension from a component
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
 
+
+
 ## `reactive-graph components update-description`
 
 Updates the description of a component
@@ -854,11 +1016,15 @@ Updates the description of a component
 * `<NAME>` — The component name
 * `<DESCRIPTION>` — The description to update
 
+
+
 ## `reactive-graph components json-schema`
 
 Prints the JSON Schema of components
 
 **Usage:** `reactive-graph components json-schema`
+
+
 
 ## `reactive-graph entity-types`
 
@@ -873,6 +1039,7 @@ Manage entity types
 * `list-properties` — List the properties of an entity type
 * `list-extensions` — List the extensions of an entity type
 * `list-components` — List the components of an entity type
+* `get-json-schema` — Prints the JSON Schema of an entity type
 * `create` — Creates a new entity type
 * `delete` — Deletes a entity type
 * `add-property` — Adds a property to an entity type
@@ -890,11 +1057,16 @@ Manage entity types
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph entity-types list`
 
 List all entity types
 
 **Usage:** `reactive-graph entity-types list`
+
+
 
 ## `reactive-graph entity-types get`
 
@@ -907,6 +1079,8 @@ Prints a single entity type
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
 
+
+
 ## `reactive-graph entity-types list-properties`
 
 List the properties of an entity type
@@ -917,6 +1091,8 @@ List the properties of an entity type
 
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
+
+
 
 ## `reactive-graph entity-types list-extensions`
 
@@ -929,6 +1105,8 @@ List the extensions of an entity type
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
 
+
+
 ## `reactive-graph entity-types list-components`
 
 List the components of an entity type
@@ -939,6 +1117,21 @@ List the components of an entity type
 
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
+
+
+
+## `reactive-graph entity-types get-json-schema`
+
+Prints the JSON Schema of an entity type
+
+**Usage:** `reactive-graph entity-types get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The entity type namespace
+* `<NAME>` — The entity type name
+
+
 
 ## `reactive-graph entity-types create`
 
@@ -952,6 +1145,8 @@ Creates a new entity type
 * `<NAME>` — The entity type name
 * `<DESCRIPTION>` — The entity type description
 
+
+
 ## `reactive-graph entity-types delete`
 
 Deletes a entity type
@@ -962,6 +1157,8 @@ Deletes a entity type
 
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
+
+
 
 ## `reactive-graph entity-types add-property`
 
@@ -979,6 +1176,8 @@ Adds a property to an entity type
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph entity-types remove-property`
 
 Removes a property from an entity type
@@ -990,6 +1189,8 @@ Removes a property from an entity type
 * `<NAMESPACE>` — The entity type namespace
 * `<NAME>` — The entity type name
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph entity-types add-extension`
 
@@ -1006,6 +1207,8 @@ Adds an extension to an entity type
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph entity-types remove-extension`
 
 Removes an extension from an entity type
@@ -1018,6 +1221,8 @@ Removes an extension from an entity type
 * `<NAME>` — The entity type name
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
+
+
 
 ## `reactive-graph entity-types add-component`
 
@@ -1032,6 +1237,8 @@ Adds a component to an entity type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph entity-types remove-component`
 
 Removes a component from an entity type
@@ -1045,6 +1252,8 @@ Removes a component from an entity type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph entity-types update-description`
 
 Updates the description of an entity type
@@ -1057,11 +1266,15 @@ Updates the description of an entity type
 * `<NAME>` — The entity type name
 * `<DESCRIPTION>` — The description to update
 
+
+
 ## `reactive-graph entity-types json-schema`
 
 Prints the JSON Schema of entity types
 
 **Usage:** `reactive-graph entity-types json-schema`
+
+
 
 ## `reactive-graph relation-types`
 
@@ -1076,6 +1289,7 @@ Manage entity types
 * `list-properties` — List the properties of an relation type
 * `list-extensions` — List the extensions of an relation type
 * `list-components` — List the components of an relation type
+* `get-json-schema` — Prints the JSON Schema of an relation type
 * `create` — Creates a new relation type
 * `delete` — Deletes a relation type
 * `add-property` — Adds a property to a relation type
@@ -1093,11 +1307,16 @@ Manage entity types
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph relation-types list`
 
 List all relation types
 
 **Usage:** `reactive-graph relation-types list`
+
+
 
 ## `reactive-graph relation-types get`
 
@@ -1110,6 +1329,8 @@ Prints a single relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 
+
+
 ## `reactive-graph relation-types list-properties`
 
 List the properties of an relation type
@@ -1120,6 +1341,8 @@ List the properties of an relation type
 
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
+
+
 
 ## `reactive-graph relation-types list-extensions`
 
@@ -1132,6 +1355,8 @@ List the extensions of an relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 
+
+
 ## `reactive-graph relation-types list-components`
 
 List the components of an relation type
@@ -1143,12 +1368,26 @@ List the components of an relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 
+
+
+## `reactive-graph relation-types get-json-schema`
+
+Prints the JSON Schema of an relation type
+
+**Usage:** `reactive-graph relation-types get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The relation type namespace
+* `<NAME>` — The relation type name
+
+
+
 ## `reactive-graph relation-types create`
 
 Creates a new relation type
 
-**Usage:**
-`reactive-graph relation-types create <OUTBOUND_TYPE_NAMESPACE> <OUTBOUND_TYPE_NAME> <NAMESPACE> <NAME> <INBOUND_TYPE_NAMESPACE> <INBOUND_TYPE_NAME> [DESCRIPTION]`
+**Usage:** `reactive-graph relation-types create <OUTBOUND_TYPE_NAMESPACE> <OUTBOUND_TYPE_NAME> <NAMESPACE> <NAME> <INBOUND_TYPE_NAMESPACE> <INBOUND_TYPE_NAME> [DESCRIPTION]`
 
 ###### **Arguments:**
 
@@ -1160,6 +1399,8 @@ Creates a new relation type
 * `<INBOUND_TYPE_NAME>` — The inbound entity type name
 * `<DESCRIPTION>` — The relation type description
 
+
+
 ## `reactive-graph relation-types delete`
 
 Deletes a relation type
@@ -1170,6 +1411,8 @@ Deletes a relation type
 
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
+
+
 
 ## `reactive-graph relation-types add-property`
 
@@ -1187,6 +1430,8 @@ Adds a property to a relation type
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph relation-types remove-property`
 
 Removes a property from a relation type
@@ -1198,6 +1443,8 @@ Removes a property from a relation type
 * `<NAMESPACE>` — The relation type namespace
 * `<NAME>` — The relation type name
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph relation-types add-extension`
 
@@ -1214,6 +1461,8 @@ Adds an extension to a relation type
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph relation-types remove-extension`
 
 Removes an extension from a relation type
@@ -1226,6 +1475,8 @@ Removes an extension from a relation type
 * `<NAME>` — The relation type name
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
+
+
 
 ## `reactive-graph relation-types add-component`
 
@@ -1240,6 +1491,8 @@ Adds a component to a relation type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph relation-types remove-component`
 
 Removes a component from a relation type
@@ -1253,6 +1506,8 @@ Removes a component from a relation type
 * `<COMPONENT_NAMESPACE>` — The component namespace
 * `<COMPONENT_NAME>` — The component name
 
+
+
 ## `reactive-graph relation-types update-description`
 
 Updates the description of a relation type
@@ -1265,11 +1520,15 @@ Updates the description of a relation type
 * `<NAME>` — The relation type name
 * `<DESCRIPTION>` — The description to update
 
+
+
 ## `reactive-graph relation-types json-schema`
 
 Prints the JSON Schema of relation types
 
 **Usage:** `reactive-graph relation-types json-schema`
+
+
 
 ## `reactive-graph flow-types`
 
@@ -1283,6 +1542,7 @@ Manage entity types
 * `get` — Prints a single flow type
 * `list-variables` — List the variables of a flow type
 * `list-extensions` — List the extensions of a flow type
+* `get-json-schema` — Prints the JSON Schema of a flow type
 * `create` — Creates a new flow type
 * `delete` — Deletes a flow type
 * `add-variable` — Adds a property to a flow type
@@ -1300,11 +1560,16 @@ Manage entity types
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph flow-types list`
 
 List all flow types
 
 **Usage:** `reactive-graph flow-types list`
+
+
 
 ## `reactive-graph flow-types get`
 
@@ -1317,6 +1582,8 @@ Prints a single flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 
+
+
 ## `reactive-graph flow-types list-variables`
 
 List the variables of a flow type
@@ -1327,6 +1594,8 @@ List the variables of a flow type
 
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
+
+
 
 ## `reactive-graph flow-types list-extensions`
 
@@ -1339,12 +1608,26 @@ List the extensions of a flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 
+
+
+## `reactive-graph flow-types get-json-schema`
+
+Prints the JSON Schema of a flow type
+
+**Usage:** `reactive-graph flow-types get-json-schema <NAMESPACE> <NAME>`
+
+###### **Arguments:**
+
+* `<NAMESPACE>` — The flow type namespace
+* `<NAME>` — The flow type name
+
+
+
 ## `reactive-graph flow-types create`
 
 Creates a new flow type
 
-**Usage:**
-`reactive-graph flow-types create <NAMESPACE> <NAME> <ENTITY_TYPE_NAMESPACE> <ENTITY_TYPE_NAME> <WRAPPER_ENTITY_INSTANCE_ID> [DESCRIPTION] [WRAPPER_ENTITY_INSTANCE_DESCRIPTION]`
+**Usage:** `reactive-graph flow-types create <NAMESPACE> <NAME> <ENTITY_TYPE_NAMESPACE> <ENTITY_TYPE_NAME> <WRAPPER_ENTITY_INSTANCE_ID> [DESCRIPTION] [WRAPPER_ENTITY_INSTANCE_DESCRIPTION]`
 
 ###### **Arguments:**
 
@@ -1356,6 +1639,8 @@ Creates a new flow type
 * `<DESCRIPTION>` — The flow type description
 * `<WRAPPER_ENTITY_INSTANCE_DESCRIPTION>` — The description of the wrapper entity instance
 
+
+
 ## `reactive-graph flow-types delete`
 
 Deletes a flow type
@@ -1366,6 +1651,8 @@ Deletes a flow type
 
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
+
+
 
 ## `reactive-graph flow-types add-variable`
 
@@ -1383,6 +1670,8 @@ Adds a property to a flow type
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph flow-types remove-variable`
 
 Removes a property from a flow type
@@ -1394,6 +1683,8 @@ Removes a property from a flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 * `<VARIABLE_NAME>` — The name of the variable
+
+
 
 ## `reactive-graph flow-types add-extension`
 
@@ -1410,6 +1701,8 @@ Adds an extension to a flow type
 * `<DESCRIPTION>` — Textual description of the extension
 * `<EXTENSION>` — The extension as JSON representation
 
+
+
 ## `reactive-graph flow-types remove-extension`
 
 Removes an extension from a flow type
@@ -1423,6 +1716,8 @@ Removes an extension from a flow type
 * `<EXTENSION_NAMESPACE>` — The extension namespace
 * `<EXTENSION_NAME>` — The extension name
 
+
+
 ## `reactive-graph flow-types update-description`
 
 Updates the description of a flow type
@@ -1434,6 +1729,8 @@ Updates the description of a flow type
 * `<NAMESPACE>` — The flow type namespace
 * `<NAME>` — The flow type name
 * `<DESCRIPTION>` — The description to update
+
+
 
 ## `reactive-graph flow-types add-entity-instance`
 
@@ -1454,6 +1751,8 @@ Adds a new entity instance to a flow type
 * `-d`, `--description <DESCRIPTION>` — The entity instance description
 * `-p`, `--properties <PROPERTIES>` — The entity instance properties
 
+
+
 ## `reactive-graph flow-types remove-entity-instance`
 
 Removes an entity instance to a flow type
@@ -1466,11 +1765,15 @@ Removes an entity instance to a flow type
 * `<NAME>` — The flow type name
 * `<ID>` — The entity instance to remove from the flow type
 
+
+
 ## `reactive-graph flow-types json-schema`
 
 Prints the JSON Schema of flow types
 
 **Usage:** `reactive-graph flow-types json-schema`
+
+
 
 ## `reactive-graph entity-instances`
 
@@ -1501,6 +1804,9 @@ Manage entity instances
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph entity-instances list`
 
 List all entity instances
@@ -1516,6 +1822,8 @@ List all entity instances
 * `-p`, `--properties <PROPERTIES>` — The properties to search for
 * `-c`, `--components <COMPONENTS>` — The components to search for
 
+
+
 ## `reactive-graph entity-instances get`
 
 Prints a single entity instance
@@ -1525,6 +1833,8 @@ Prints a single entity instance
 ###### **Arguments:**
 
 * `<ID>` — The id of the entity instance
+
+
 
 ## `reactive-graph entity-instances get-by-label`
 
@@ -1536,6 +1846,8 @@ Prints a single entity instance
 
 * `<LABEL>` — The label of the reactive instance
 
+
+
 ## `reactive-graph entity-instances list-properties`
 
 Lists the properties of an entity instance
@@ -1545,6 +1857,8 @@ Lists the properties of an entity instance
 ###### **Arguments:**
 
 * `<ID>` — The id of the entity instance
+
+
 
 ## `reactive-graph entity-instances get-property`
 
@@ -1556,6 +1870,8 @@ Prints the value of a property of an entity instance
 
 * `<ID>` — The id of the entity instance
 * `<PROPERTY_NAME>` — The name of the property
+
+
 
 ## `reactive-graph entity-instances set-property`
 
@@ -1569,7 +1885,9 @@ Sets the value of a property of an entity instance
 * `<NAME>` — The name of the property
 * `<VALUE>` — The new JSON value of the property.
 
-  'true' is boolean true, '"true"' is the string "true"
+   'true' is boolean true, '"true"' is the string "true"
+
+
 
 ## `reactive-graph entity-instances add-property`
 
@@ -1586,6 +1904,8 @@ Adds a new property to an entity instance
 * `<MUTABILITY>` — If the property is mutable or not
 * `<DESCRIPTION>` — Description of the property
 
+
+
 ## `reactive-graph entity-instances remove-property`
 
 Removes a property from an entity instance
@@ -1597,6 +1917,8 @@ Removes a property from an entity instance
 * `<ID>` — The id of the entity instance
 * `<PROPERTY_NAME>` — The name of the property
 
+
+
 ## `reactive-graph entity-instances list-components`
 
 Lists the components of an entity instance
@@ -1606,6 +1928,8 @@ Lists the components of an entity instance
 ###### **Arguments:**
 
 * `<ID>` — The id of the entity instance
+
+
 
 ## `reactive-graph entity-instances add-component`
 
@@ -1619,6 +1943,8 @@ Adds a component to an entity instance
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
 
+
+
 ## `reactive-graph entity-instances remove-component`
 
 Removes a component from an entity instance
@@ -1630,6 +1956,8 @@ Removes a component from an entity instance
 * `<ID>` — The id of the reactive instance
 * `<NAMESPACE>` — The component namespace
 * `<NAME>` — The component name
+
+
 
 ## `reactive-graph entity-instances create`
 
@@ -1648,6 +1976,8 @@ Creates a new entity type
 * `-d`, `--description <DESCRIPTION>` — The entity instance description
 * `-p`, `--properties <PROPERTIES>` — The entity instance properties
 
+
+
 ## `reactive-graph entity-instances delete`
 
 CLI argument which identifies an entity instance by its id
@@ -1658,11 +1988,15 @@ CLI argument which identifies an entity instance by its id
 
 * `<ID>` — The id of the entity instance
 
+
+
 ## `reactive-graph entity-instances json-schema`
 
 Prints the JSON Schema of entity instances
 
 **Usage:** `reactive-graph entity-instances json-schema`
+
+
 
 ## `reactive-graph relation-instances`
 
@@ -1692,6 +2026,9 @@ Manage relation instances
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph relation-instances list`
 
 List all relation instances
@@ -1706,6 +2043,8 @@ List all relation instances
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 * `-p`, `--properties <PROPERTIES>` — The properties to search for
 * `-c`, `--components <COMPONENTS>` — The components to search for
+
+
 
 ## `reactive-graph relation-instances get`
 
@@ -1724,6 +2063,8 @@ Prints a single relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances list-properties`
 
 Lists the properties of a relation instance
@@ -1741,12 +2082,13 @@ Lists the properties of a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances get-property`
 
 Prints the value of a property of a relation instance
 
-**Usage:**
-`reactive-graph relation-instances get-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
+**Usage:** `reactive-graph relation-instances get-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
 
 ###### **Arguments:**
 
@@ -1760,12 +2102,13 @@ Prints the value of a property of a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances set-property`
 
 Sets the value of a property of a relation instance
 
-**Usage:**
-`reactive-graph relation-instances set-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <PROPERTY_VALUE>`
+**Usage:** `reactive-graph relation-instances set-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <PROPERTY_VALUE>`
 
 ###### **Arguments:**
 
@@ -1775,19 +2118,20 @@ Sets the value of a property of a relation instance
 * `<PROPERTY_NAME>` — The name of the property
 * `<PROPERTY_VALUE>` — The JSON value of the property.
 
-  'true' is boolean true, '"true"' is the string "true"
+   'true' is boolean true, '"true"' is the string "true"
 
 ###### **Options:**
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances add-property`
 
 Adds a new property to a relation instance
 
-**Usage:**
-`reactive-graph relation-instances add-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]`
+**Usage:** `reactive-graph relation-instances add-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME> <DATA_TYPE> <SOCKET_TYPE> <MUTABILITY> [DESCRIPTION]`
 
 ###### **Arguments:**
 
@@ -1805,12 +2149,13 @@ Adds a new property to a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances remove-property`
 
 Removes a property from a relation instance
 
-**Usage:**
-`reactive-graph relation-instances remove-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
+**Usage:** `reactive-graph relation-instances remove-property --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <PROPERTY_NAME>`
 
 ###### **Arguments:**
 
@@ -1823,6 +2168,8 @@ Removes a property from a relation instance
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
+
+
 
 ## `reactive-graph relation-instances list-components`
 
@@ -1841,12 +2188,13 @@ Lists the components of a relation instance
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances add-component`
 
 Adds a component to a relation instance
 
-**Usage:**
-`reactive-graph relation-instances add-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
+**Usage:** `reactive-graph relation-instances add-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
 
 ###### **Arguments:**
 
@@ -1860,13 +2208,14 @@ Adds a component to a relation instance
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
+
+
 
 ## `reactive-graph relation-instances remove-component`
 
 Removes a component from a relation instance
 
-**Usage:**
-`reactive-graph relation-instances remove-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
+**Usage:** `reactive-graph relation-instances remove-component --outbound-id <OUTBOUND_ID> --inbound-id <INBOUND_ID> <NAMESPACE> <NAME> <INSTANCE_ID> <COMPONENT_NAMESPACE> <COMPONENT_NAME>`
 
 ###### **Arguments:**
 
@@ -1880,6 +2229,8 @@ Removes a component from a relation instance
 
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
+
+
 
 ## `reactive-graph relation-instances create`
 
@@ -1900,6 +2251,8 @@ Creates a new relation type
 * `-d`, `--description <DESCRIPTION>` — The relation instance description
 * `-p`, `--properties <PROPERTIES>` — The relation instance properties
 
+
+
 ## `reactive-graph relation-instances delete`
 
 CLI argument which identifies an relation instance by its id
@@ -1917,11 +2270,15 @@ CLI argument which identifies an relation instance by its id
 * `--outbound-id <OUTBOUND_ID>` — The id of the outbound entity instance
 * `-i`, `--inbound-id <INBOUND_ID>` — The id of the inbound entity instance
 
+
+
 ## `reactive-graph relation-instances json-schema`
 
 Prints the JSON Schema of relation instances
 
 **Usage:** `reactive-graph relation-instances json-schema`
+
+
 
 ## `reactive-graph flow-instances`
 
@@ -1944,6 +2301,9 @@ Manage flow instances
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 ## `reactive-graph flow-instances list`
 
 List all flow instances
@@ -1957,6 +2317,8 @@ List all flow instances
 * `-i`, `--id <ID>` — The id of the entity instance
 * `-l`, `--label <LABEL>` — The label of the entity instance
 
+
+
 ## `reactive-graph flow-instances get`
 
 Prints a single flow instance
@@ -1967,6 +2329,8 @@ Prints a single flow instance
 
 * `<ID>` — The id of the flow instance
 
+
+
 ## `reactive-graph flow-instances get-by-label`
 
 Prints a single flow instance
@@ -1976,6 +2340,8 @@ Prints a single flow instance
 ###### **Arguments:**
 
 * `<LABEL>` — The label of the reactive instance
+
+
 
 ## `reactive-graph flow-instances create-from-type`
 
@@ -1994,6 +2360,8 @@ Creates a new flow from the given type
 * `-v`, `--variables <VARIABLES>` — The entity instance properties
 * `-p`, `--properties <PROPERTIES>` — The entity instance properties
 
+
+
 ## `reactive-graph flow-instances delete`
 
 CLI argument which identifies a flow instance by its id
@@ -2004,11 +2372,15 @@ CLI argument which identifies a flow instance by its id
 
 * `<ID>` — The id of the flow instance
 
+
+
 ## `reactive-graph flow-instances json-schema`
 
 Prints the JSON Schema of flow instances
 
 **Usage:** `reactive-graph flow-instances json-schema`
+
+
 
 ## `reactive-graph introspection`
 
@@ -2023,11 +2395,15 @@ Execute GraphQL introspection queries
 * `reactive-graph-runtime` — Get the GraphQL schema of the reactive graph runtime
 * `reactive-graph-plugins` — Get the GraphQL schema of the plugin system of reactive graph
 
+
+
 ## `reactive-graph introspection reactive-graph`
 
 Get the GraphQL schema of the reactive graph
 
 **Usage:** `reactive-graph introspection reactive-graph`
+
+
 
 ## `reactive-graph introspection dynamic-graph`
 
@@ -2035,17 +2411,23 @@ Get the GraphQL schema of the dynamic graph
 
 **Usage:** `reactive-graph introspection dynamic-graph`
 
+
+
 ## `reactive-graph introspection reactive-graph-runtime`
 
 Get the GraphQL schema of the reactive graph runtime
 
 **Usage:** `reactive-graph introspection reactive-graph-runtime`
 
+
+
 ## `reactive-graph introspection reactive-graph-plugins`
 
 Get the GraphQL schema of the plugin system of reactive graph
 
 **Usage:** `reactive-graph introspection reactive-graph-plugins`
+
+
 
 ## `reactive-graph instances`
 
@@ -2065,6 +2447,8 @@ Manage instances
 
 * `<WORKING_DIRECTORY>` — The working directory of the instance. Defaults to the current directory
 
+
+
 ## `reactive-graph instances config`
 
 Configures a local instance,
@@ -2076,6 +2460,8 @@ Configures a local instance,
 * `graphql` — Configures the GraphQL server
 * `instance` — Configures the instance
 * `plugins` — Configures the instance
+
+
 
 ## `reactive-graph instances config graphql`
 
@@ -2093,10 +2479,11 @@ Configures the GraphQL server
 
 * `--ssl-certificate-path <SSL_CERTIFICATE_PATH>` — The location of the certificate
 * `--ssl-private-key-path <SSL_PRIVATE_KEY_PATH>` — The location of the private key
-* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to
-  finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
+* `--shutdown-timeout <SHUTDOWN_TIMEOUT>` — Timeout for graceful workers shutdown in seconds. After receiving a stop signal, workers have this much time to finish serving requests. Workers still alive after the timeout are force dropped. By default, shutdown timeout sets to 30 seconds
 * `-w`, `--workers <WORKERS>` — The number of workers to start. The default worker count is the number of physical CPU cores available
 * `-c`, `--default-context-path <DEFAULT_CONTEXT_PATH>` — The default context path which redirects the root context to a web resource provider
+
+
 
 ## `reactive-graph instances config instance`
 
@@ -2108,6 +2495,8 @@ Configures the instance
 
 * `-n`, `--instance-name <NAME>` — The name of the instance
 * `-d`, `--instance-description <DESCRIPTION>` — The description of the instance
+
+
 
 ## `reactive-graph instances config plugins`
 
@@ -2130,6 +2519,8 @@ Configures the instance
 * `--hot-deploy-location <HOT_DEPLOY_LOCATION>` — The folder which is watched for hot deployment
 * `--install-location <INSTALL_LOCATION>` — The folder which plugins are installed permanently
 
+
+
 ## `reactive-graph instances generate-certificate`
 
 Generates certificate of a local instance
@@ -2141,6 +2532,8 @@ Generates certificate of a local instance
 * `<COUNTRY_NAME>` — Country name
 * `<ORGANIZATION_NAME>` — Organization name
 * `<COMMON_NAME>` — Common name
+
+
 
 ## `reactive-graph instances init`
 
@@ -2159,6 +2552,8 @@ Initialize the filesystem structure of a new local instance
 * `--uid <UID>` — The numeric user id of the owner user
 * `--gid <GID>` — The numeric group id of the owner group
 
+
+
 ## `reactive-graph instances plugins`
 
 Manage the plugins of a local instance
@@ -2170,6 +2565,8 @@ Manage the plugins of a local instance
 * `install` — Installs a plugin
 * `uninstall` — Uninstalls a plugin
 
+
+
 ## `reactive-graph instances plugins install`
 
 Installs a plugin
@@ -2179,6 +2576,8 @@ Installs a plugin
 ###### **Arguments:**
 
 * `<PLUGIN_NAME>` — The name of the plugin
+
+
 
 ## `reactive-graph instances plugins uninstall`
 
@@ -2190,6 +2589,8 @@ Uninstalls a plugin
 
 * `<PLUGIN_NAME>` — The name of the plugin
 
+
+
 ## `reactive-graph instances repository`
 
 Manage the repositories of a local instance
@@ -2200,6 +2601,8 @@ Manage the repositories of a local instance
 
 * `init` — Initializes a new local repository in a local instance
 * `remove` — Removes a local repository
+
+
 
 ## `reactive-graph instances repository init`
 
@@ -2217,6 +2620,8 @@ Initializes a new local repository in a local instance
 * `--uid <UID>` — The numeric user id of the owner user
 * `--gid <GID>` — The numeric group id of the owner group
 
+
+
 ## `reactive-graph instances repository remove`
 
 Removes a local repository
@@ -2229,6 +2634,9 @@ Removes a local repository
 * `<FORCE>` — If true, the default repository will be deleted
 
   Possible values: `true`, `false`
+
+
+
 
 ## `reactive-graph update`
 
@@ -2252,6 +2660,8 @@ Update the Reactive Graph binary
 * `-q`, `--quiet` — Hides the download progress and the output
 * `-y`, `--no-confirm` — Don't ask
 
+
+
 ## `reactive-graph update info`
 
 Shows information about the selected release
@@ -2263,6 +2673,9 @@ Shows information about the selected release
 * `--output-format <OUTPUT_FORMAT>` — The output format
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
+
+
+
 
 ## `reactive-graph update list`
 
@@ -2276,9 +2689,13 @@ Lists the releases
 
   Possible values: `table`, `html-table`, `markdown-table`, `count`, `json`, `json5`, `toml`
 
+
+
+
 <hr/>
 
 <small><i>
-This document was generated automatically by
-<a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/schema/graphql/reactive-graph-runtime-schema.graphql
+++ b/schema/graphql/reactive-graph-runtime-schema.graphql
@@ -42,9 +42,7 @@ input InstanceAddress {
 	
 	Defaults to `false`.
 	
-	# Warning
-	
-	You should think very carefully before using this method. If
+	Warning: You should think very carefully before using this method. If
 	invalid certificates are trusted, *any* certificate for *any* site
 	will be trusted for use. This includes expired certificates. This
 	introduces significant vulnerabilities, and should only be used
@@ -56,9 +54,7 @@ input InstanceAddress {
 	
 	Defaults to `false`.
 	
-	# Warning
-	
-	You should think very carefully before you use this method. If
+	Warning: You should think very carefully before you use this method. If
 	hostname verification is not used, any valid certificate for any
 	site will be trusted for use from any other. This introduces a
 	significant vulnerability to man-in-the-middle attacks.


### PR DESCRIPTION
## [0.10.0-alpha-5] - 2025-08-01

Improves plugin support in docker containers

### Added

- CLI: Added arguments `--danger_accept_invalid_certs` and `--danger_accept_invalid_hostnames`

### Changed

- Plugins: Improved error message if moving plugin from `plugins/deploy` to `plugins/installed` failed

### Fixed

- Docker: Run configurations for docker containers mount the plugin deploy folder of the workspace on the container (note: this works only if you're running a
  single container)
- Docker: Plugin system now correctly handles deploying plugins when the deploy folder is mounted as volume

### Distribution

- Docker: Dockerfile now uses ubuntu 24.04 as runtime image
- Docker: Added Dockerfile.debian which uses bookworm-slim as base image
- Docker: Added docker-compose which contains an init container for installing plugins (respects arch + configurable with a tag/version)

### Infrastructure

- The standard library plugins are now provided via [GitHub Releases](https://github.com/reactive-graph/std/releases/tag/nightly)