### PR TITLE
Avoid conflicting json schema fields in the dynamic graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid conflicting json schema fields in the dynamic graph
+
 ### Distribution
 
 - Provisioning standard library plugins or another set of plugins

--- a/crates/dynamic-graph/impl/src/object/namespace/schema.rs
+++ b/crates/dynamic-graph/impl/src/object/namespace/schema.rs
@@ -8,8 +8,12 @@ use schemars::Schema;
 pub const FIELD_JSON_SCHEMA_APPENDIX: &str = "JsonSchema";
 
 pub fn json_schema_field<TY: Into<DynamicGraphTypeDefinition>>(ty: TY, schema: Schema) -> Field {
-    Field::new(ty.into().field_name_with_appendix(FIELD_JSON_SCHEMA_APPENDIX), TypeRef::named_nn("JSON"), move |_ctx| {
-        let schema = schema.clone();
-        FieldFuture::new(async move { Ok(to_field_value(schema.as_value().clone())) })
-    })
+    Field::new(
+        ty.into().field_name_with_suffix_and_appendix(FIELD_JSON_SCHEMA_APPENDIX),
+        TypeRef::named_nn("JSON"),
+        move |_ctx| {
+            let schema = schema.clone();
+            FieldFuture::new(async move { Ok(to_field_value(schema.as_value().clone())) })
+        },
+    )
 }

--- a/crates/dynamic-graph/impl/src/object/types.rs
+++ b/crates/dynamic-graph/impl/src/object/types.rs
@@ -33,6 +33,10 @@ impl DynamicGraphTypeDefinition {
         format!("{}{}", self.field_name(), self.ty.type_id_type.full_name())
     }
 
+    pub fn field_name_with_suffix_and_appendix(&self, appendix: &str) -> String {
+        format!("{}{}{}", self.ty.type_name.to_case(Pascal), self.ty.type_id_type.full_name(), appendix)
+    }
+
     pub fn outbound_type_name(&self) -> String {
         format!("outbound_{}_{}", &self.ty.namespace, &self.ty.type_name)
     }


### PR DESCRIPTION
If a component and an entity type have the same type name the name of the graphql field is the same and prevents to generate the dynamic graph